### PR TITLE
fix: use actual validator count for SSV cluster runway

### DIFF
--- a/src/hooks/cluster/use-cluster-runway.ts
+++ b/src/hooks/cluster/use-cluster-runway.ts
@@ -60,16 +60,13 @@ export const useClusterRunway = (
 
   const feesPerBlock = operatorFees + networkFee;
 
-  const clusterEffectiveBalance = BigInt(cluster.data?.effectiveBalance ?? 0);
-  const minClusterEffectiveBalance =
-    BigInt(cluster.data?.validatorCount ?? 1) * 32n;
-
-  const effectiveBalance = bigintMax(
-    clusterEffectiveBalance,
-    minClusterEffectiveBalance,
-  );
-
-  const validators = (effectiveBalance + state.effectiveBalance) / 32n;
+  const validators = isETH
+    ? bigintMax(
+        BigInt(cluster.data?.effectiveBalance ?? 0),
+        BigInt(cluster.data?.validatorCount ?? 1) * 32n,
+      ) / 32n +
+      state.effectiveBalance / 32n
+    : BigInt(cluster.data?.validatorCount ?? 1);
 
   const isLoading =
     cluster.isLoading ||


### PR DESCRIPTION
## Summary
- SSV clusters were deriving validator count from `effectiveBalance / 32`, which inflated the count when effective balance exceeded `validatorCount * 32` (e.g., 160 ETH → 5 validators instead of actual 2)
- Now SSV clusters use `validatorCount` directly for runway calculation, while ETH (migrated) clusters keep the effective balance logic
- Fixes runway showing ~97 days instead of the correct ~263 days for the reported cluster

## Test plan
- [ ] Verify SSV cluster runway matches expected value (e.g., ~263 days for the reported cluster with 2 validators)
- [ ] Verify ETH (migrated) cluster runway is unchanged
- [ ] Verify deposit/withdraw runway delta calculations still work correctly for both cluster types

🤖 Generated with [Claude Code](https://claude.com/claude-code)