### PR TITLE
fix: allow zero effective balance when cluster has no validators

### DIFF
--- a/src/components/effective-balance/effective-balance-form.tsx
+++ b/src/components/effective-balance/effective-balance-form.tsx
@@ -63,17 +63,16 @@ export const EffectiveBalanceForm: FC<EffectiveBalanceFormProps> = ({
 
   const maxEffectiveBalance = validatorCount * 2048;
 
-  const schema = useMemo(
-    () =>
-      z.object({
-        totalEffectiveBalance: z
-          .number()
-          .positive({ message: "Balance must be greater than 0" })
-          .min(estimatedEffectiveBalance)
-          .max(maxEffectiveBalance),
-      }),
-    [estimatedEffectiveBalance, maxEffectiveBalance],
-  );
+  const schema = useMemo(() => {
+    let balanceSchema = z
+      .number()
+      .nonnegative({ message: "Balance must be 0 or greater" })
+      .min(estimatedEffectiveBalance);
+    if (maxEffectiveBalance > 0) {
+      balanceSchema = balanceSchema.max(maxEffectiveBalance);
+    }
+    return z.object({ totalEffectiveBalance: balanceSchema });
+  }, [estimatedEffectiveBalance, maxEffectiveBalance]);
   const totalEffectiveBalance = Number(
     forceInitialBalance || estimatedEffectiveBalance,
   );


### PR DESCRIPTION
When reactivating a liquidated cluster with no validators, the schema now allows 0 as a valid effective balance instead of requiring a positive number. Also skips the max constraint when validatorCount is 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)