### PR TITLE
fix: preserve EB precision in runway and funding calculations (post-Pectra)

### DIFF
--- a/src/hooks/cluster/use-cluster-runway.ts
+++ b/src/hooks/cluster/use-cluster-runway.ts
@@ -7,10 +7,10 @@ import { useNetworkFee, useNetworkFeeSSV } from "@/hooks/use-ssv-network-fee";
 import { sumOperatorsFee } from "@/lib/utils/operator";
 import { useOperators } from "@/hooks/operator/use-operators";
 
-const getDeltaValidators = (options: Options) => {
-  if ("deltaValidators" in options) return options.deltaValidators ?? 0n;
+const getDeltaEffectiveBalance = (options: Options) => {
+  if ("deltaValidators" in options) return (options.deltaValidators ?? 0n) * 32n;
   if ("deltaEffectiveBalance" in options)
-    return BigInt(options.deltaEffectiveBalance ?? 0) / 32n;
+    return BigInt(options.deltaEffectiveBalance ?? 0);
   return 0n;
 };
 
@@ -32,7 +32,7 @@ export const useClusterRunway = (
   const params = useClusterPageParams();
   const clusterHash = hash ?? params.clusterHash;
 
-  const deltaValidators = getDeltaValidators(opts);
+  const deltaEffectiveBalance = getDeltaEffectiveBalance(opts);
 
   const cluster = useCluster(clusterHash, { watch: opts.watch });
   const balance = useClusterBalance(clusterHash!, { watch: opts.watch });
@@ -57,12 +57,12 @@ export const useClusterRunway = (
 
   const feesPerBlock = operatorFees + networkFee;
 
-  const validators = isETH
+  const effectiveBalance = isETH
     ? bigintMax(
         BigInt(cluster.data?.effectiveBalance ?? 0),
         BigInt(cluster.data?.validatorCount ?? 1) * 32n,
-      ) / 32n
-    : BigInt(cluster.data?.validatorCount ?? 1);
+      )
+    : BigInt(cluster.data?.validatorCount ?? 1) * 32n;
 
   const isLoading =
     cluster.isLoading ||
@@ -74,8 +74,8 @@ export const useClusterRunway = (
   const runway = calculateRunway({
     balance: (isETH ? balance.data.eth : balance.data.ssv) || 0n,
     feesPerBlock,
-    validators,
-    deltaValidators: deltaValidators,
+    effectiveBalance,
+    deltaEffectiveBalance: deltaEffectiveBalance,
     deltaBalance: opts.deltaBalance ?? 0n,
     liquidationThresholdBlocks,
     minimumLiquidationCollateral,

--- a/src/lib/utils/cluster.ts
+++ b/src/lib/utils/cluster.ts
@@ -100,24 +100,29 @@ export const filterOutRemovedValidators = (
 type CalculateRunwayParams = {
   balance: bigint;
   feesPerBlock: bigint;
-  validators: bigint;
+  effectiveBalance: bigint;
   deltaBalance?: bigint;
-  deltaValidators?: bigint;
+  deltaEffectiveBalance?: bigint;
   liquidationThresholdBlocks: bigint;
   minimumLiquidationCollateral: bigint;
 };
 
+const EB_PER_VALIDATOR = 32n;
+
 export const calculateRunway = ({
   balance,
   feesPerBlock,
-  validators,
+  effectiveBalance,
   deltaBalance = 0n,
-  deltaValidators = 0n,
+  deltaEffectiveBalance = 0n,
   liquidationThresholdBlocks,
   minimumLiquidationCollateral,
 }: CalculateRunwayParams) => {
-  const burnRateSnapshot = feesPerBlock * (validators || 1n);
-  const burnRateWithDelta = feesPerBlock * (validators + deltaValidators);
+  // Multiply before dividing to preserve precision for non-32-multiple EBs (post-Pectra)
+  const snapshotEB = effectiveBalance || EB_PER_VALIDATOR;
+  const totalEB = effectiveBalance + deltaEffectiveBalance;
+  const burnRateSnapshot = (feesPerBlock * snapshotEB) / EB_PER_VALIDATOR;
+  const burnRateWithDelta = (feesPerBlock * (totalEB || EB_PER_VALIDATOR)) / EB_PER_VALIDATOR;
 
   const collateralSnapshot = bigintMax(
     burnRateSnapshot * liquidationThresholdBlocks,

--- a/src/lib/utils/keystore.ts
+++ b/src/lib/utils/keystore.ts
@@ -24,11 +24,13 @@ export const computeLiquidationCollateralCostPerValidator = ({
   minimumLiquidationCollateral,
   effectiveBalance,
 }: LiquidationCollateralCostArgs) => {
-  const validators = effectiveBalance / 32n || 1n;
+  const eb = effectiveBalance || 32n;
+  const validators = eb / 32n || 1n;
+  // Multiply before dividing to preserve precision for non-32-multiple EBs
   const total =
     (operatorsFee + networkFee) *
     liquidationCollateralPeriod *
-    BigInt(validators);
+    eb / 32n;
 
   return bigintMax(total, minimumLiquidationCollateral) / validators;
 };
@@ -41,16 +43,17 @@ type ComputeFundingCostArgs = Prettify<
 >;
 
 export const computeFundingCost = (args: ComputeFundingCostArgs) => {
-  const validators = args.effectiveBalance / 32n || 1n;
+  const eb = args.effectiveBalance || 32n;
+  const validators = eb / 32n || 1n;
 
   const networkCost = computeDailyAmount(args.networkFee, args.fundingDays);
   const operatorsCost = computeDailyAmount(args.operatorsFee, args.fundingDays);
   const liquidationCollateral =
     computeLiquidationCollateralCostPerValidator(args);
 
-  // Subtotal = base cost × effective balance × validators
-  const networkCostSubtotal = networkCost * validators;
-  const operatorsCostSubtotal = operatorsCost * validators;
+  // Multiply before dividing to preserve precision for non-32-multiple EBs
+  const networkCostSubtotal = (networkCost * eb) / 32n;
+  const operatorsCostSubtotal = (operatorsCost * eb) / 32n;
   const liquidationCollateralSubtotal = liquidationCollateral * validators;
 
   const total =
@@ -59,7 +62,7 @@ export const computeFundingCost = (args: ComputeFundingCostArgs) => {
   const runway = calculateRunway({
     balance: total,
     feesPerBlock: args.networkFee + args.operatorsFee,
-    validators,
+    effectiveBalance: eb,
     liquidationThresholdBlocks: args.liquidationCollateralPeriod,
     minimumLiquidationCollateral: args.minimumLiquidationCollateral,
   });


### PR DESCRIPTION
## Summary

- **Fix integer division precision loss** in runway, funding cost, and liquidation collateral calculations
- Post-Pectra (EIP-7251), validators can have effective balance > 32 ETH. The previous code divided EB by 32 early (`effectiveBalance / 32n`), losing up to 31 ETH per cluster due to BigInt truncation
- Fix: multiply `fees × EB` first, then divide by 32 last — precision loss drops from whole ETH-units to 1 wei-unit

### Impact (before fix)

| Validator EB | `EB / 32` (true) | `EB / 32n` (BigInt) | Fee underestimate |
|-------------|------------------|---------------------|-------------------|
| 32 ETH | 1.000 | 1 | 0% |
| 33 ETH | 1.031 | 1 | **3.1%** |
| 48 ETH | 1.500 | 1 | **33%** |
| 63 ETH | 1.969 | 1 | **49%** |

### Files changed

- `src/lib/utils/cluster.ts` — `calculateRunway` accepts `effectiveBalance` instead of pre-divided `validators`
- `src/hooks/cluster/use-cluster-runway.ts` — passes raw EB without early `/ 32n`
- `src/lib/utils/keystore.ts` — funding cost and liquidation collateral use `(cost × EB) / 32n`

### External API unchanged

`useClusterRunway` hook callers still pass `deltaValidators` or `deltaEffectiveBalance` — conversion happens internally.

## Test plan

- [ ] Verify runway display for cluster with 32 ETH validators (should be unchanged)
- [ ] Verify runway display for cluster with >32 ETH validators (should show shorter/more accurate runway)
- [ ] Verify funding cost calculation on initial-funding and reactivate pages
- [ ] Verify liquidation collateral calculation

🤖 Generated with [Claude Code](https://claude.com/claude-code)