### PR TITLE
fix: align migration flow liquidation collateral with actual effective balance

### DIFF
--- a/src/app/routes/switch-wizard/switch-wizard-step-two.tsx
+++ b/src/app/routes/switch-wizard/switch-wizard-step-two.tsx
@@ -45,7 +45,6 @@ export const SwitchWizardStepTwoRoute = () => {
       navigateRoutePath={`${basePath}/step-one`}
       navigateRouteOptions={from ? { state: { from } } : undefined}
       operators={operators}
-      validatorsAmount={cluster.data?.validatorCount ?? 1}
       effectiveBalance={effectiveBalance}
       currentRunwayDays={Number(clusterRunway?.runway) || 0}
       ssvBalance={balanceSSV.data}

--- a/src/components/wizard/switch-wizard-step-two.tsx
+++ b/src/components/wizard/switch-wizard-step-two.tsx
@@ -38,7 +38,6 @@ type SwitchWizardStepTwoProps = {
   navigateRoutePath?: string;
   navigateRouteOptions?: NavigateOptions;
   operators?: Pick<Operator, "id" | "name" | "logo" | "fee" | "eth_fee">[];
-  validatorsAmount?: number;
   effectiveBalance?: bigint;
   currentRunwayDays?: number;
   ssvBalance?: bigint;
@@ -65,7 +64,6 @@ export const SwitchWizardStepTwo = ({
   navigateRoutePath,
   navigateRouteOptions,
   operators = [],
-  validatorsAmount = 1,
   effectiveBalance,
   currentRunwayDays = 0,
   ssvBalance,
@@ -120,7 +118,7 @@ export const SwitchWizardStepTwo = ({
       operatorsFee,
       liquidationCollateralPeriod: liquidationThreshold,
       minimumLiquidationCollateral,
-      effectiveBalance: BigInt(validatorsAmount || 1) * 32n,
+      effectiveBalance: effectiveBalanceWei,
     });
 
     const operatorsPerEth = operatorsCost;


### PR DESCRIPTION
## Summary
- The migration flow's funding summary was passing `validatorsAmount * 32` as the effective balance to `computeLiquidationCollateralCostPerValidator`, while the subtotal was scaled by the real effective balance from step 1.5
- This mismatch caused incorrect liquidation collateral values when EB wasn't a perfect multiple of 32 ETH
- Now passes the actual `effectiveBalanceWei`, consistent with how the onboarding flow calculates it via `computeFundingCost()`

## Test plan
- [ ] Open the cluster migration wizard for a cluster whose effective balance is **not** a clean multiple of 32 ETH
- [ ] Verify the liquidation collateral "Fee" and "Subtotal" columns in the funding summary are consistent
- [ ] Compare values with the onboarding flow's funding summary for the same operators/EB — they should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)