### PR TITLE
fix: update Hoodi testnet contract addresses to v2.0.0

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -19,4 +19,4 @@ VITE_MIXPANEL_TOKEN=$MIXPANEL_TOKEN
 # ---------------------------------------------------------
 
 # Mainnet + Hoodi
-VITE_SSV_NETWORKS='[{"networkId":560048,"api":"https://api.stage.ops.ssvlabsinternal.com/api","apiVersion":"v4","apiNetwork":"hoodi","explorerUrl":"https://explorer.stage.ssv.network","insufficientBalanceUrl":"https://faucet.stage.ssv.network","googleTagSecret":"GTM-K3GR7M5","tokenAddress":"0x746c33ccc28b1363c35c09badaf41b2ffa7e6d56","setterContractAddress":"0x0aaace4e8affc47c6834171c88d342a4abd8f105","getterContractAddress":"0x9143b8c25efa53f28de4cbefd0b6dfd66d43fea6"}]'
+VITE_SSV_NETWORKS='[{"networkId":560048,"api":"https://api.stage.ops.ssvlabsinternal.com/api","apiVersion":"v4","apiNetwork":"hoodi","explorerUrl":"https://explorer.stage.ssv.network","insufficientBalanceUrl":"https://faucet.stage.ssv.network","googleTagSecret":"GTM-K3GR7M5","tokenAddress":"0x746c33ccc28b1363c35c09badaf41b2ffa7e6d56","setterContractAddress":"0xc07B3E9671f884FDa67E1e7D43d952E0e1369fd8","getterContractAddress":"0x3234e84b7d1eE1AF8b586E26814d4e268336D142"}]'

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -41,8 +41,8 @@ jobs:
             \"insufficientBalanceUrl\": \"https://faucet.stage.ssv.network\",
             \"googleTagSecret\": \"${{ secrets.STAGE_GOOGLE_TAG_SECRET }}\",
             \"tokenAddress\": \"0x746c33ccc28b1363c35c09badaf41b2ffa7e6d56\",
-            \"setterContractAddress\": \"0x0aaace4e8affc47c6834171c88d342a4abd8f105\",
-            \"getterContractAddress\": \"0x9143b8c25efa53f28de4cbefd0b6dfd66d43fea6\"
+            \"setterContractAddress\": \"0xc07B3E9671f884FDa67E1e7D43d952E0e1369fd8\",
+            \"getterContractAddress\": \"0x3234e84b7d1eE1AF8b586E26814d4e268336D142\"
            }
         ]
       PROD_SSV_NETWORKS: >


### PR DESCRIPTION
Update setter and getter contract addresses for Hoodi network in both development env and CI/CD workflow configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)