### PR TITLE
fix: correct operator fee calculation in migration flow

### DIFF
--- a/src/app/routes/switch-wizard/switch-wizard-step-three.tsx
+++ b/src/app/routes/switch-wizard/switch-wizard-step-three.tsx
@@ -85,7 +85,6 @@ export const SwitchWizardStepThreeRoute = () => {
       fundingSummary={fundingSummary}
       effectiveBalance={effectiveBalance}
       totalDeposit={totalDeposit}
-      validatorsAmount={cluster.data?.validatorCount ?? 1}
       withdrawSsvBalance={balanceSSV.data}
       isSubmitting={migrate.isPending}
       isSubmitDisabled={!canSubmit}

--- a/src/components/wizard/switch-wizard-step-three.tsx
+++ b/src/components/wizard/switch-wizard-step-three.tsx
@@ -9,10 +9,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Tooltip } from "@/components/ui/tooltip";
 import { FaCircleInfo } from "react-icons/fa6";
 import type { Operator } from "@/types/api";
-import { getYearlyFee } from "@/lib/utils/operator";
-import { currencyFormatter, formatETH, formatSSV } from "@/lib/utils/number";
-import { formatUnits } from "viem";
-import { useRates } from "@/hooks/use-rates";
+import { useMigrationCalculationData } from "@/hooks/use-migration-calculation-data";
 import type { SwitchWizardFundingSummary } from "./switch-wizard-types";
 import type { NavigateOptions } from "react-router-dom";
 
@@ -27,7 +24,6 @@ type SwitchWizardStepThreeProps = {
   totalDeposit?: bigint;
   effectiveBalance?: bigint;
   fundingSummary?: SwitchWizardFundingSummary;
-  validatorsAmount?: number;
   withdrawSsvBalance?: bigint;
   isSubmitting?: boolean;
   isSubmitDisabled?: boolean;
@@ -44,42 +40,29 @@ export const SwitchWizardStepThree = ({
   totalDeposit,
   effectiveBalance,
   fundingSummary,
-  validatorsAmount,
   withdrawSsvBalance,
   isSubmitting = false,
   isSubmitDisabled = false,
 }: SwitchWizardStepThreeProps) => {
   const [isAcknowledged, setIsAcknowledged] = useState(false);
   const acknowledgeId = useId();
-  const rates = useRates();
-  const ethRate = rates.data?.eth ?? 0;
-  const ssvRate = rates.data?.ssv ?? 0;
-  const validatorsCount = validatorsAmount ?? 1;
-  const isMultiValidator = validatorsCount > 1;
 
-  const formatEthDisplay = (value: bigint) => `${formatETH(value)} ETH`;
-  const formatUsd = (value: bigint) =>
-    `~${currencyFormatter.format(ethRate * +formatUnits(value, 18))}`;
-  const formatEthValue = (value?: bigint) =>
-    value !== undefined ? formatEthDisplay(value) : "-";
-
-  const effectiveBalanceDisplay =
-    effectiveBalance !== undefined ? formatEthDisplay(effectiveBalance) : "-";
-  const totalDepositFallback = fundingSummary
-    ? fundingSummary.operatorsSubtotal +
-      fundingSummary.networkSubtotal +
-      fundingSummary.liquidationSubtotal
-    : undefined;
-  const withdrawSsvDisplay =
-    withdrawSsvBalance !== undefined
-      ? `${formatSSV(withdrawSsvBalance)} SSV`
-      : "0 SSV";
-  const withdrawSsvUsd =
-    withdrawSsvBalance !== undefined
-      ? `~${currencyFormatter.format(
-          ssvRate * Number(formatUnits(withdrawSsvBalance, 18)),
-        )}`
-      : "";
+  const {
+    operatorFees,
+    effectiveBalanceDisplay,
+    totalDepositDisplay,
+    totalDepositUsd,
+    withdrawSsvDisplay,
+    withdrawSsvUsd,
+    formatEthValue,
+  } = useMigrationCalculationData({
+    operators,
+    fundingDays,
+    effectiveBalance,
+    fundingSummary,
+    totalDeposit,
+    withdrawSsvBalance,
+  });
 
   const handleSubmit = () => {
     if (!isAcknowledged || isSubmitting || isSubmitDisabled) return;
@@ -107,15 +90,8 @@ export const SwitchWizardStepThree = ({
           <Text variant="body-3-semibold" className="text-gray-500">
             Selected Operators
           </Text>
-          {operators.map((operator) => {
-            const yearlyEthFee = getYearlyFee(BigInt(operator.eth_fee || "0"));
-            const yearlyEthFeeDisplay = isMultiValidator
-              ? yearlyEthFee * BigInt(validatorsCount)
-              : yearlyEthFee;
-            const yearlyFeeSuffix = isMultiValidator
-              ? ` (total for ${validatorsCount} validators)`
-              : "";
-
+          {operatorFees.map((opFee, index) => {
+            const operator = operators[index];
             return (
               <div
                 className="flex justify-between items-center"
@@ -127,10 +103,10 @@ export const SwitchWizardStepThree = ({
                 />
                 <div className="text-end space-y-1">
                   <Text variant="body-2-medium">
-                    {formatEthDisplay(yearlyEthFeeDisplay)}
+                    {opFee.periodFeeDisplay}
                   </Text>
                   <Text variant="body-3-medium" className="text-gray-500">
-                    {formatUsd(yearlyEthFeeDisplay)} /year{yearlyFeeSuffix}
+                    {opFee.periodFeeUsd} /{fundingDays} days
                   </Text>
                 </div>
               </div>
@@ -207,17 +183,9 @@ export const SwitchWizardStepThree = ({
           <div className="flex items-start justify-between">
             <Text variant="body-2-medium">Total Deposit</Text>
             <div className="flex flex-col items-end">
-              <Text variant="headline4">
-                {totalDeposit !== undefined
-                  ? formatEthDisplay(totalDeposit)
-                  : formatEthValue(totalDepositFallback)}
-              </Text>
+              <Text variant="headline4">{totalDepositDisplay}</Text>
               <Text variant="body-3-medium" className="text-gray-500">
-                {totalDeposit !== undefined
-                  ? formatUsd(totalDeposit)
-                  : totalDepositFallback !== undefined
-                    ? formatUsd(totalDepositFallback)
-                    : ""}
+                {totalDepositUsd}
               </Text>
             </div>
           </div>

--- a/src/hooks/use-migration-calculation-data.ts
+++ b/src/hooks/use-migration-calculation-data.ts
@@ -1,0 +1,111 @@
+import { computeDailyAmount } from "@/lib/utils/keystore";
+import type { Operator } from "@/types/api";
+import { useRates } from "@/hooks/use-rates";
+import { currencyFormatter, formatETH } from "@/lib/utils/number";
+import { formatUnits } from "viem";
+import type { SwitchWizardFundingSummary } from "@/components/wizard/switch-wizard-types";
+
+type OperatorFeeDisplay = {
+  operatorId: number;
+  periodFee: bigint;
+  periodFeeDisplay: string;
+  periodFeeUsd: string;
+};
+
+type UseMigrationCalculationDataArgs = {
+  operators: Pick<Operator, "id" | "name" | "logo" | "eth_fee">[];
+  fundingDays: number;
+  effectiveBalance?: bigint;
+  fundingSummary?: SwitchWizardFundingSummary;
+  totalDeposit?: bigint;
+  withdrawSsvBalance?: bigint;
+};
+
+/**
+ * Hook for calculating and formatting all data needed in the migration flow.
+ * Handles operator fees, funding summary, and display formatting.
+ *
+ * Operator fees are calculated per period (not yearly) for 32 ETH validator.
+ * Multiplication by validator count happens in Funding Summary through Effective Balance.
+ */
+export const useMigrationCalculationData = ({
+  operators,
+  fundingDays,
+  effectiveBalance,
+  fundingSummary,
+  totalDeposit,
+  withdrawSsvBalance,
+}: UseMigrationCalculationDataArgs) => {
+  const rates = useRates();
+  const ethRate = rates.data?.eth ?? 0;
+  const ssvRate = rates.data?.ssv ?? 0;
+
+  // Format helpers
+  const formatEthDisplay = (value: bigint) => `${formatETH(value)} ETH`;
+  const formatUsd = (value: bigint) =>
+    `~${currencyFormatter.format(ethRate * +formatUnits(value, 18))}`;
+  const formatEthValue = (value?: bigint) =>
+    value !== undefined ? formatEthDisplay(value) : "-";
+
+  // Calculate operator fees for the selected period (per 32 ETH validator)
+  const operatorFees: OperatorFeeDisplay[] = operators.map((operator) => {
+    const periodFee = computeDailyAmount(
+      BigInt(operator.eth_fee || "0"),
+      fundingDays,
+    );
+    return {
+      operatorId: operator.id,
+      periodFee,
+      periodFeeDisplay: formatEthDisplay(periodFee),
+      periodFeeUsd: formatUsd(periodFee),
+    };
+  });
+
+  // Effective Balance display
+  const effectiveBalanceDisplay =
+    effectiveBalance !== undefined ? formatEthDisplay(effectiveBalance) : "-";
+
+  // Total deposit calculation
+  const totalDepositFallback = fundingSummary
+    ? fundingSummary.operatorsSubtotal +
+      fundingSummary.networkSubtotal +
+      fundingSummary.liquidationSubtotal
+    : undefined;
+
+  const totalDepositDisplay =
+    totalDeposit !== undefined
+      ? formatEthDisplay(totalDeposit)
+      : formatEthValue(totalDepositFallback);
+
+  const totalDepositUsd =
+    totalDeposit !== undefined
+      ? formatUsd(totalDeposit)
+      : totalDepositFallback !== undefined
+        ? formatUsd(totalDepositFallback)
+        : "";
+
+  // SSV withdrawal display
+  const withdrawSsvDisplay =
+    withdrawSsvBalance !== undefined
+      ? `${formatETH(withdrawSsvBalance)} SSV`
+      : "0 SSV";
+
+  const withdrawSsvUsd =
+    withdrawSsvBalance !== undefined
+      ? `~${currencyFormatter.format(
+          ssvRate * Number(formatUnits(withdrawSsvBalance, 18)),
+        )}`
+      : "";
+
+  return {
+    operatorFees,
+    effectiveBalanceDisplay,
+    totalDepositDisplay,
+    totalDepositUsd,
+    withdrawSsvDisplay,
+    withdrawSsvUsd,
+    formatEthValue,
+    ethRate,
+    ssvRate,
+  };
+};


### PR DESCRIPTION
Created useMigrationCalculationData hook that centralizes all calculations for the migration flow. Operator fees are now calculated correctly:
- Fee per period (not yearly)
- Per 32 ETH validator (not multiplied by validator count)
- Multiplication by validators happens in Funding Summary through Effective Balance

This fixes the issue where operator fees were incorrectly displayed as:
- Yearly fee (0.0093 ETH) instead of period fee (0.0046257 ETH)
- Multiplied by validator count

🤖 Generated with [Claude Code](https://claude.com/claude-code)