### PR TITLE
fix: re-enable remove validators

### DIFF
--- a/src/components/cluster/cluster-validators-list.tsx
+++ b/src/components/cluster/cluster-validators-list.tsx
@@ -94,15 +94,14 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
                       </DropdownMenuItem>
                     </a>
                     <DropdownMenuItem
-                      disabled={isSsvCluster}
                       onClick={() => {
-                        if (isSsvCluster) return;
                         useBulkActionContext.state.selectedPublicKeys = [
                           item.public_key,
                         ];
                         navigate("remove/confirmation");
                       }}
                     >
+                      /
                       <LuTrash2 className="size-4" />
                       <span>Remove Validator</span>
                     </DropdownMenuItem>

--- a/src/components/cluster/cluster-validators-list.tsx
+++ b/src/components/cluster/cluster-validators-list.tsx
@@ -101,7 +101,6 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
                         navigate("remove/confirmation");
                       }}
                     >
-                      /
                       <LuTrash2 className="size-4" />
                       <span>Remove Validator</span>
                     </DropdownMenuItem>

--- a/src/components/cluster/validators-actions-menu.tsx
+++ b/src/components/cluster/validators-actions-menu.tsx
@@ -62,21 +62,12 @@ export const ValidatorsActionsMenu: FC<ButtonProps & Props> = ({
       </DropdownMenuTrigger>
 
       <DropdownMenuContent>
-        <Tooltip
-          side="right"
-          delayDuration={0}
-          content={isSsvCluster ? "Switch to ETH to enable this option" : undefined}
+        <DropdownMenuItem
+          onClick={() => onActionClickHandler(ActionType.Remove)}
         >
-          <div>
-            <DropdownMenuItem
-              disabled={isSsvCluster}
-              onClick={() => onActionClickHandler(ActionType.Remove)}
-            >
-              <LuTrash2 className="size-4" />
-              <span>Remove Validators</span>
-            </DropdownMenuItem>
-          </div>
-        </Tooltip>
+          <LuTrash2 className="size-4" />
+          <span>Remove Validators</span>
+        </DropdownMenuItem>
 
         <Tooltip
           side="right"
@@ -98,27 +89,29 @@ export const ValidatorsActionsMenu: FC<ButtonProps & Props> = ({
           </div>
         </Tooltip>
         {allOperatorsHaveValidDkgAddress ? (
-           <>
-          <div className="w-full h-[1px] bg-gray-300" />
-          <div className="h-9 flex items-center text-gray-500 text-xs	font-semibold pl-[16px]">
-            DKG
-          </div>
-          <Tooltip
-            side="right"
-            delayDuration={0}
-            content={isSsvCluster ? "Switch to ETH to enable this option" : undefined}
-          >
-            <div>
-              <DropdownMenuItem
-                disabled={isSsvCluster}
-                onClick={() => onActionClickHandler(ActionType.Reshare)}
-              >
-                <TbRefreshDot className="size-4" />
-                <span>Reshare</span>
-              </DropdownMenuItem>
+          <>
+            <div className="w-full h-[1px] bg-gray-300" />
+            <div className="h-9 flex items-center text-gray-500 text-xs	font-semibold pl-[16px]">
+              DKG
             </div>
-          </Tooltip>
-        </>
+            <Tooltip
+              side="right"
+              delayDuration={0}
+              content={
+                isSsvCluster ? "Switch to ETH to enable this option" : undefined
+              }
+            >
+              <div>
+                <DropdownMenuItem
+                  disabled={isSsvCluster}
+                  onClick={() => onActionClickHandler(ActionType.Reshare)}
+                >
+                  <TbRefreshDot className="size-4" />
+                  <span>Reshare</span>
+                </DropdownMenuItem>
+              </div>
+            </Tooltip>
+          </>
         ) : null}
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
### F-ssv-web-015 — Re-enable Remove Option in Legacy SSV Clusters (✅ Done)


- **Problem:** The "Remove" action in legacy SSV clusters is currently disabled in the UI.
- **Fix:** Re-enable the remove action in the UI. **Pre-condition:** confirm with Marco that the contract on stage has been upgraded to support this before shipping. Do not enable in the UI until contract-side support is confirmed on stage.
- **Validation:** Remove action is visible and functional on legacy SSV clusters on stage/Hoodi. Non-legacy clusters are unaffected.
- **How to QA:** Attempt remove on a legacy SSV cluster; verify action appears and executes correctly. Verify the action does not appear where it shouldn't.