### PR TITLE
fix: hide Active badge on cluster header (#1806)

### DIFF
--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-header.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-header.tsx
@@ -60,12 +60,11 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
               <CopyBtn text={clusterId} />
             </div>
 
-            <Badge
-              variant={isLiquidatedCluster ? "error" : "success"}
-              size="xs"
-            >
-              {isLiquidatedCluster ? "Liquidated" : "Active"}
-            </Badge>
+            {isLiquidatedCluster && (
+              <Badge variant="error" size="xs">
+                Liquidated
+              </Badge>
+            )}
           </div>
 
           <Tooltip


### PR DESCRIPTION
Only show the badge when cluster is liquidated.