### PR TITLE
ci: add geo API key env vars to all builds

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -98,12 +98,18 @@ jobs:
           SSV_NETWORKS="${{ env.STAGE_SSV_NETWORKS }}"
           MIXPANEL_TOKEN_STAGE="${{ secrets.MIXPANEL_TOKEN_STAGE }}"
           LINK_SSV_DEV_DOCS="$LINK_SSV_DEV_DOCS"
+          VITE_IPGEO_API_KEY="${{ secrets.VITE_IPGEO_API_KEY }}"
+          VITE_IPREGISTRY_KEY="${{ secrets.VITE_IPREGISTRY_KEY }}"
+          VITE_BIGDATACLOUD_KEY="${{ secrets.VITE_BIGDATACLOUD_KEY }}"
           pnpm build
         env:
           GAS_PRICE: ${{ secrets.GAS_PRICE }}
           GAS_LIMIT: ${{ secrets.GAS_LIMIT }}
           LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_STAGE }}
+          VITE_IPGEO_API_KEY: ${{ secrets.VITE_IPGEO_API_KEY }}
+          VITE_IPREGISTRY_KEY: ${{ secrets.VITE_IPREGISTRY_KEY }}
+          VITE_BIGDATACLOUD_KEY: ${{ secrets.VITE_BIGDATACLOUD_KEY }}
 
       - name: Upload files to S3
         if: github.ref == 'refs/heads/pre-stage'
@@ -115,17 +121,23 @@ jobs:
       - name: Run stage webapp build
         if: github.ref == 'refs/heads/stage'
         run: >
-          GAS_PRICE="${{ env.GAS_PRICE }}" 
+          GAS_PRICE="${{ env.GAS_PRICE }}"
           GAS_LIMIT="${{ env.GAS_LIMIT }}"
           SSV_NETWORKS="${{ env.STAGE_SSV_NETWORKS }}"
           MIXPANEL_TOKEN_STAGE="${{ secrets.MIXPANEL_TOKEN_STAGE }}"
-          LINK_SSV_DEV_DOCS="$LINK_SSV_DEV_DOCS" 
+          LINK_SSV_DEV_DOCS="$LINK_SSV_DEV_DOCS"
+          VITE_IPGEO_API_KEY="${{ secrets.VITE_IPGEO_API_KEY }}"
+          VITE_IPREGISTRY_KEY="${{ secrets.VITE_IPREGISTRY_KEY }}"
+          VITE_BIGDATACLOUD_KEY="${{ secrets.VITE_BIGDATACLOUD_KEY }}"
           pnpm build
         env:
           GAS_PRICE: ${{ secrets.GAS_PRICE }}
           GAS_LIMIT: ${{ secrets.GAS_LIMIT }}
           LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_STAGE }}
+          VITE_IPGEO_API_KEY: ${{ secrets.VITE_IPGEO_API_KEY }}
+          VITE_IPREGISTRY_KEY: ${{ secrets.VITE_IPREGISTRY_KEY }}
+          VITE_BIGDATACLOUD_KEY: ${{ secrets.VITE_BIGDATACLOUD_KEY }}
 
       - name: Upload files to S3
         if: github.ref == 'refs/heads/stage'
@@ -137,12 +149,15 @@ jobs:
       - name: Run prod webapp build
         if: github.ref == 'refs/heads/main'
         run: >
-          GAS_PRICE="${{ env.GAS_PRICE }}" 
+          GAS_PRICE="${{ env.GAS_PRICE }}"
           GAS_LIMIT="${{ env.GAS_LIMIT }}"
           SSV_NETWORKS="${{ env.PROD_SSV_NETWORKS }}"
           MIXPANEL_TOKEN_PROD="${{ secrets.MIXPANEL_TOKEN_PROD }}"
           LINK_SSV_DEV_DOCS="$LINK_SSV_DEV_DOCS"
           SENTRY_AUTH_TOKEN="${{ secrets.SENTRY_AUTH_TOKEN }}"
+          VITE_IPGEO_API_KEY="${{ secrets.VITE_IPGEO_API_KEY }}"
+          VITE_IPREGISTRY_KEY="${{ secrets.VITE_IPREGISTRY_KEY }}"
+          VITE_BIGDATACLOUD_KEY="${{ secrets.VITE_BIGDATACLOUD_KEY }}"
           pnpm build
         env:
           GAS_PRICE: ${{ secrets.GAS_PRICE }}
@@ -150,6 +165,9 @@ jobs:
           LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_PROD }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_IPGEO_API_KEY: ${{ secrets.VITE_IPGEO_API_KEY }}
+          VITE_IPREGISTRY_KEY: ${{ secrets.VITE_IPREGISTRY_KEY }}
+          VITE_BIGDATACLOUD_KEY: ${{ secrets.VITE_BIGDATACLOUD_KEY }}
 
       - name: Upload files to S3
         if: github.ref == 'refs/heads/main'
@@ -167,6 +185,9 @@ jobs:
           MIXPANEL_TOKEN_PROD="${{ secrets.MIXPANEL_TOKEN_PROD }}"
           LINK_SSV_DEV_DOCS="$LINK_SSV_DEV_DOCS"
           SENTRY_AUTH_TOKEN="${{ secrets.SENTRY_AUTH_TOKEN }}"
+          VITE_IPGEO_API_KEY="${{ secrets.VITE_IPGEO_API_KEY }}"
+          VITE_IPREGISTRY_KEY="${{ secrets.VITE_IPREGISTRY_KEY }}"
+          VITE_BIGDATACLOUD_KEY="${{ secrets.VITE_BIGDATACLOUD_KEY }}"
           pnpm build
         env:
           GAS_PRICE: ${{ secrets.GAS_PRICE }}
@@ -174,6 +195,9 @@ jobs:
           LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_PROD }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_IPGEO_API_KEY: ${{ secrets.VITE_IPGEO_API_KEY }}
+          VITE_IPREGISTRY_KEY: ${{ secrets.VITE_IPREGISTRY_KEY }}
+          VITE_BIGDATACLOUD_KEY: ${{ secrets.VITE_BIGDATACLOUD_KEY }}
 
       - name: Upload files to S3
         if: github.ref == 'refs/heads/bapps-prod'


### PR DESCRIPTION
## Summary
- Add `VITE_IPGEO_API_KEY`, `VITE_IPREGISTRY_KEY`, `VITE_BIGDATACLOUD_KEY` to all build steps (pre-stage, stage, main, bapps-prod)
- Each var is passed inline in the `run:` command and declared in the step `env:` block, consistent with existing secret-based vars like `LINK_SSV_DEV_DOCS`
- Secrets must be added to GitHub repository secrets before merging

## Test plan
- [ ] Add the 3 secrets to GitHub repo secrets: `VITE_IPGEO_API_KEY`, `VITE_IPREGISTRY_KEY`, `VITE_BIGDATACLOUD_KEY`
- [ ] Verify build passes and the vars are available at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)