### PR TITLE
ci: add geo API key env vars to all builds

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -123,13 +123,19 @@ jobs:
           VITE_EXPLORER_URL="https://explorer.stage.ssv.network"
           VITE_STAKE_URL="https://stake.ssv.network/"
           MIXPANEL_TOKEN_STAGE="${{ secrets.MIXPANEL_TOKEN_STAGE }}"
-          LINK_SSV_DEV_DOCS="$LINK_SSV_DEV_DOCS" 
+          LINK_SSV_DEV_DOCS="$LINK_SSV_DEV_DOCS"
+          VITE_IPGEO_API_KEY="${{ secrets.VITE_IPGEO_API_KEY }}"
+          VITE_IPREGISTRY_KEY="${{ secrets.VITE_IPREGISTRY_KEY }}"
+          VITE_BIGDATACLOUD_KEY="${{ secrets.VITE_BIGDATACLOUD_KEY }}"
           pnpm build
         env:
           GAS_PRICE: ${{ secrets.GAS_PRICE }}
           GAS_LIMIT: ${{ secrets.GAS_LIMIT }}
           LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_STAGE }}
+          VITE_IPGEO_API_KEY: ${{ secrets.VITE_IPGEO_API_KEY }}
+          VITE_IPREGISTRY_KEY: ${{ secrets.VITE_IPREGISTRY_KEY }}
+          VITE_BIGDATACLOUD_KEY: ${{ secrets.VITE_BIGDATACLOUD_KEY }}
 
       - name: Upload files to S3
         if: github.ref == 'refs/heads/stage'
@@ -140,7 +146,7 @@ jobs:
       - name: Run prod webapp build
         if: github.ref == 'refs/heads/temporary-hoodi-deploy'
         run: >
-          GAS_PRICE="${{ env.GAS_PRICE }}" 
+          GAS_PRICE="${{ env.GAS_PRICE }}"
           GAS_LIMIT="${{ env.GAS_LIMIT }}"
           SSV_NETWORKS="${{ env.PROD_SSV_NETWORKS }}"
           VITE_EXPLORER_URL="https://explorer.ssv.network"
@@ -148,6 +154,9 @@ jobs:
           MIXPANEL_TOKEN_PROD="${{ secrets.MIXPANEL_TOKEN_PROD }}"
           LINK_SSV_DEV_DOCS="$LINK_SSV_DEV_DOCS"
           SENTRY_AUTH_TOKEN="${{ secrets.SENTRY_AUTH_TOKEN }}"
+          VITE_IPGEO_API_KEY="${{ secrets.VITE_IPGEO_API_KEY }}"
+          VITE_IPREGISTRY_KEY="${{ secrets.VITE_IPREGISTRY_KEY }}"
+          VITE_BIGDATACLOUD_KEY="${{ secrets.VITE_BIGDATACLOUD_KEY }}"
           pnpm build
         env:
           GAS_PRICE: ${{ secrets.GAS_PRICE }}
@@ -155,6 +164,9 @@ jobs:
           LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_PROD }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_IPGEO_API_KEY: ${{ secrets.VITE_IPGEO_API_KEY }}
+          VITE_IPREGISTRY_KEY: ${{ secrets.VITE_IPREGISTRY_KEY }}
+          VITE_BIGDATACLOUD_KEY: ${{ secrets.VITE_BIGDATACLOUD_KEY }}
 
       - name: Upload files to S3
         if: github.ref == 'refs/heads/temporary-hoodi-deploy'
@@ -173,6 +185,9 @@ jobs:
           MIXPANEL_TOKEN_PROD="${{ secrets.MIXPANEL_TOKEN_PROD }}"
           LINK_SSV_DEV_DOCS="$LINK_SSV_DEV_DOCS"
           SENTRY_AUTH_TOKEN="${{ secrets.SENTRY_AUTH_TOKEN }}"
+          VITE_IPGEO_API_KEY="${{ secrets.VITE_IPGEO_API_KEY }}"
+          VITE_IPREGISTRY_KEY="${{ secrets.VITE_IPREGISTRY_KEY }}"
+          VITE_BIGDATACLOUD_KEY="${{ secrets.VITE_BIGDATACLOUD_KEY }}"
           pnpm build
         env:
           GAS_PRICE: ${{ secrets.GAS_PRICE }}
@@ -180,6 +195,9 @@ jobs:
           LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_PROD }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_IPGEO_API_KEY: ${{ secrets.VITE_IPGEO_API_KEY }}
+          VITE_IPREGISTRY_KEY: ${{ secrets.VITE_IPREGISTRY_KEY }}
+          VITE_BIGDATACLOUD_KEY: ${{ secrets.VITE_BIGDATACLOUD_KEY }}
 
       - name: Upload files to S3
         if: github.ref == 'refs/heads/main-preview'


### PR DESCRIPTION
## Summary
- Add `VITE_IPGEO_API_KEY`, `VITE_IPREGISTRY_KEY`, `VITE_BIGDATACLOUD_KEY` to all build steps (stage, temporary-hoodi-deploy, main-preview)
- Each var is passed inline in the `run:` command and declared in the step `env:` block, consistent with existing secret-based vars like `LINK_SSV_DEV_DOCS`
- Secrets must be added to GitHub repository secrets before merging

## Test plan
- [ ] Add the 3 secrets to GitHub repo secrets: `VITE_IPGEO_API_KEY`, `VITE_IPREGISTRY_KEY`, `VITE_BIGDATACLOUD_KEY`
- [ ] Verify build passes and the vars are available at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)