### PR TITLE
fix: optimize react query cache keys and remove duplicate fee functions

### DIFF
--- a/src/app/routes/create-cluster/initial-funding.tsx
+++ b/src/app/routes/create-cluster/initial-funding.tsx
@@ -27,7 +27,7 @@ import {
   useSelectedOperatorIds,
 } from "@/guard/register-validator-guard";
 import { useOperators } from "@/hooks/operator/use-operators";
-import { sumOperatorsFees } from "@/lib/utils/operator";
+import { sumOperatorsFee } from "@/lib/utils/operator";
 import { useNavigate } from "react-router-dom";
 import { ClusterFundingSummary } from "@/components/cluster/cluster-funding-summary";
 import { NavigateBackBtn } from "@/components/ui/navigate-back-btn";
@@ -68,7 +68,7 @@ export const InitialFunding: FCProps = ({ ...props }) => {
   const operatorIds = useSelectedOperatorIds();
 
   const operators = useOperators(operatorIds);
-  const operatorsFee = sumOperatorsFees(operators.data ?? []);
+  const operatorsFee = sumOperatorsFee(operators.data ?? []);
 
   const computeFundingCost = useComputeFundingCost();
 

--- a/src/hooks/use-compute-funding-cost.ts
+++ b/src/hooks/use-compute-funding-cost.ts
@@ -67,7 +67,7 @@ export const useFundingCostETH = ({
     gcTime: 0,
     queryKey: stringifyBigints([
       "fundingCost",
-      operators,
+      operators.map(op => op.id),
       fundingDays,
       effectiveBalance,
       ignoreRemovedOperators,

--- a/src/lib/utils/operator.ts
+++ b/src/lib/utils/operator.ts
@@ -259,9 +259,6 @@ export const createOperatorFromEvent = (
   });
 };
 
-export const sumOperatorsFees = (operators: Operator[]) =>
-  operators.reduce((acc, operator) => acc + BigInt(operator.eth_fee), 0n);
-
 export const canAccountUseOperator = async (
   account: Address,
   operator: Pick<


### PR DESCRIPTION
Fix F-ssv-web-028: Use operator IDs in funding cost query key
- Replace full operator objects with operators.map(op => op.id) in queryKey
- Prevents unnecessary cache invalidation when operator properties change
- Cache now only invalidates when operator composition changes

Fix F-ssv-web-029: Remove duplicate sumOperatorsFees function
- Consolidate to single sumOperatorsFee function with flexible parameters
- Update initial-funding.tsx to use sumOperatorsFee
- Remove redundant sumOperatorsFees (plural) from operator.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)