### PR TITLE
fix: include eth_fee and is_deleted in funding cost cache key (F-ssv-…

### DIFF
--- a/src/hooks/use-compute-funding-cost.ts
+++ b/src/hooks/use-compute-funding-cost.ts
@@ -67,7 +67,7 @@ export const useFundingCostETH = ({
     gcTime: 0,
     queryKey: stringifyBigints([
       "fundingCost",
-      operators.map(op => op.id),
+      operators.map(op => ({ id: op.id, eth_fee: op.eth_fee, is_deleted: op.is_deleted })),
       fundingDays,
       effectiveBalance,
       ignoreRemovedOperators,


### PR DESCRIPTION
…web-028)

BREAKING FIX: Previous implementation using only operator.id in cache key caused stale data when operator fees changed. Users would see incorrect funding amounts if eth_fee or is_deleted changed during the flow.

Now include all fields used in sumOperatorsFee calculation:
- id: operator identity
- eth_fee: operator's ETH fee (critical for cost calculation)
- is_deleted: whether operator is removed (affects fee calculation)

This ensures cache invalidates when fee-relevant data changes while still avoiding unnecessary invalidation on unrelated field updates (validators_count, status, etc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)