### PR TITLE
feat: include notDeposited in current and projected effective balance

### DIFF
--- a/src/app/routes/dashboard/clusters/cluster/migrated/migrated-cluster.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/migrated-cluster.tsx
@@ -36,10 +36,20 @@ export const MigratedCluster: FC = () => {
 
   const hasProjected = (effectiveBalanceBreakdown?.pending ?? 0) > 0;
 
-  const currentEffectiveBalance = Number(cluster.data?.effectiveBalance ?? 0);
-  const projectedEffectiveBalance = Number(
-    currentEffectiveBalance + (effectiveBalanceBreakdown?.pending ?? 0),
-  );
+  const currentEffectiveBalance = hasProjected
+    ? Number(
+        (effectiveBalanceBreakdown?.deposited ?? 0) +
+          (effectiveBalanceBreakdown?.notDeposited ?? 0),
+      )
+    : Number(cluster.data?.effectiveBalance ?? 0);
+
+  const projectedEffectiveBalance = hasProjected
+    ? Number(
+        (effectiveBalanceBreakdown?.deposited ?? 0) +
+          (effectiveBalanceBreakdown?.notDeposited ?? 0) +
+          (effectiveBalanceBreakdown?.pending ?? 0),
+      )
+    : currentEffectiveBalance;
 
   const operatorsUsability = useOperatorsUsability({
     account: account.address!,


### PR DESCRIPTION
When pending > 0:
- Current EB = deposited + notDeposited
- Projected EB = deposited + notDeposited + pending When no pending: keep existing behaviour (cluster.effectiveBalance)