### PR TITLE
fix: calculate projected runway with contract effective balance

### DIFF
--- a/src/app/routes/dashboard/clusters/cluster/migrated/migrated-cluster.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/migrated-cluster.tsx
@@ -95,9 +95,8 @@ export const MigratedCluster: FC = () => {
               clusterHash={clusterHash!}
               isLiquidated={Boolean(isLiquidated.data)}
               isProjected={hasProjected && isProjected}
-              deltaEffectiveBalance={BigInt(
-                effectiveBalanceBreakdown?.pending ?? 0,
-              )}
+              effectiveBalance={BigInt(currentEffectiveBalance)}
+              projectedEffectiveBalance={BigInt(projectedEffectiveBalance)}
             />
           </div>
           <Card className="flex-[2] h-full p-6">

--- a/src/app/routes/dashboard/clusters/cluster/migrated/operational-runway-card.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/operational-runway-card.tsx
@@ -19,36 +19,39 @@ type OperationalRunwayCardProps = {
   clusterHash: string;
   isLiquidated: boolean;
   isProjected: boolean;
-  deltaEffectiveBalance?: bigint;
+  effectiveBalance: bigint;
+  projectedEffectiveBalance: bigint;
 };
 
 export const OperationalRunwayCard: FC<OperationalRunwayCardProps> = ({
   clusterHash,
   isLiquidated,
   isProjected,
-  deltaEffectiveBalance = 0n,
+  effectiveBalance,
+  projectedEffectiveBalance,
 }) => {
   const cluster = useCluster(clusterHash);
   const operatorIds = cluster.data?.operators ?? [];
 
   const { data: operators } = useOperators(operatorIds);
 
-  const effectiveBalance = bigintMax(
-    BigInt(cluster.data?.effectiveBalance ?? 0),
-    BigInt(cluster.data?.validatorCount ?? 1) * 32n,
-  );
-
   const balance = useClusterBalance(clusterHash, { watch: true });
+
+  const activeEffectiveBalance = isProjected
+    ? projectedEffectiveBalance
+    : effectiveBalance;
 
   const fundingCost = useFundingCostETH({
     operators: operators ?? [],
     fundingDays: 1,
-    effectiveBalance:
-      effectiveBalance + (isProjected ? deltaEffectiveBalance : 0n),
+    effectiveBalance: activeEffectiveBalance,
   });
+
+  const deltaEffectiveBalance = projectedEffectiveBalance - effectiveBalance;
 
   const { data: runway } = useClusterRunway(clusterHash, {
     watch: true,
+    effectiveBalance: activeEffectiveBalance,
     deltaEffectiveBalance: isProjected ? deltaEffectiveBalance : undefined,
   });
 

--- a/src/hooks/cluster/use-cluster-runway.ts
+++ b/src/hooks/cluster/use-cluster-runway.ts
@@ -19,6 +19,7 @@ type Options = {
   deltaBalance?: bigint;
   watch?: boolean;
   forceMode?: "eth" | "ssv";
+  effectiveBalance?: bigint;
 } & ({ deltaValidators?: bigint } | { deltaEffectiveBalance?: bigint });
 
 export const useClusterRunway = (
@@ -58,12 +59,14 @@ export const useClusterRunway = (
 
   const feesPerBlock = operatorFees + networkFee;
 
-  const effectiveBalance = isETH
-    ? bigintMax(
-        BigInt(cluster.data?.effectiveBalance ?? 0),
-        BigInt(cluster.data?.validatorCount ?? 1) * 32n,
-      )
-    : BigInt(cluster.data?.validatorCount ?? 1) * 32n;
+  const effectiveBalance =
+    opts.effectiveBalance ??
+    (isETH
+      ? bigintMax(
+          BigInt(cluster.data?.effectiveBalance ?? 0),
+          BigInt(cluster.data?.validatorCount ?? 1) * 32n,
+        )
+      : BigInt(cluster.data?.validatorCount ?? 1) * 32n);
 
   const isLoading =
     cluster.isLoading ||


### PR DESCRIPTION
Update operational runway calculation to use contract effective balance instead of cluster data. Add effectiveBalance parameter to useClusterRunway hook with backward compatibility. Calculate burn rate and runway based on active (current or projected) effective balance for accurate projections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)