### PR TITLE
fix: remove mock data override in effective balance breakdown

### DIFF
--- a/src/hooks/cluster/use-cluster-effective-balance-breakdown.ts
+++ b/src/hooks/cluster/use-cluster-effective-balance-breakdown.ts
@@ -1,18 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import type { ValidatorsEffectiveBalanceByClusterResponse } from "@/api/validators";
 import { getValidatorsEffectiveBalanceByCluster } from "@/api/validators";
-import { useLocalStorage } from "react-use";
 
 export const useClusterEffectiveBalanceBreakdown = (clusterHash: string) => {
-  // TODO: remove this once tested
-  const [mockData] = useLocalStorage<
-    ValidatorsEffectiveBalanceByClusterResponse["effectiveBalance"] | undefined
-  >("mockEbBreakdown", undefined);
-
   return useQuery({
-    // TODO: remove mockData once tested
-    queryKey: ["validators-status-counts", clusterHash, mockData],
-    queryFn: () =>
-      mockData || getValidatorsEffectiveBalanceByCluster(clusterHash),
+    queryKey: ["validators-status-counts", clusterHash],
+    queryFn: () => getValidatorsEffectiveBalanceByCluster(clusterHash),
   });
 };


### PR DESCRIPTION
Remove development-only localStorage mock data that could silently override production API responses. This eliminates the risk of users accidentally using stale or incorrect effective balance breakdown data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)