### PR TITLE
fix: update tooltip texts and additional funding defaults

### DIFF
--- a/src/app/routes/create-cluster/additional-funding.tsx
+++ b/src/app/routes/create-cluster/additional-funding.tsx
@@ -46,7 +46,7 @@ export const AdditionalFunding: FC = () => {
   const deltaEffectiveBalance = context.effectiveBalance;
 
   const form = useForm({
-    defaultValues: { depositAmount: context.depositAmount, topUp: true },
+    defaultValues: { depositAmount: context.depositAmount, topUp: false },
     resolver: zodResolver(schema),
   });
 
@@ -186,7 +186,10 @@ export const AdditionalFunding: FC = () => {
           <Button
             type="submit"
             size="xl"
-            disabled={clusterRunway?.isAtRisk && clusterRunway?.runway < 1n}
+            disabled={
+              (topUp && depositAmount === 0n) ||
+              (clusterRunway?.isAtRisk && clusterRunway?.runway < 1n)
+            }
           >
             Next
           </Button>

--- a/src/app/routes/dashboard/clusters/cluster/bulk.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/bulk.tsx
@@ -90,7 +90,7 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
             <Text>Public key</Text>,
             <Tooltip
               asChild
-              content="Refers to the validators status in the SSV network (not beacon chain), and reflects whether its operators are consistently performing their duties (according to the last 2 epochs)"
+              content="Validator's status within the SSV network, primarily based on operator performance over the last 2 epochs, with additional context from its Beacon chain state."
             >
               <div className="flex w-fit gap-2 items-center">
                 <Text>Status</Text>

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-validators-list.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-validators-list.tsx
@@ -48,7 +48,7 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
           <Text>Public key</Text>,
           <Tooltip
             asChild
-            content="Refers to the validators status in the SSV network (not beacon chain), and reflects whether its operators are consistently performing their duties (according to the last 2 epochs)"
+            content="Validator's status within the SSV network, primarily based on operator performance over the last 2 epochs, with additional context from its Beacon chain state."
           >
             <div className="flex w-fit gap-2 items-center">
               <Text>Status</Text>

--- a/src/components/cluster/bulk-validator-picker.tsx
+++ b/src/components/cluster/bulk-validator-picker.tsx
@@ -49,7 +49,7 @@ export const BulkValidatorPicker: BulkValidatorPickerFC = ({
         <Text variant="body-2-medium">Public key</Text>,
         <Tooltip
           asChild
-          content="Refers to the validators status in the SSV network (not beacon chain), and reflects whether its operators are consistently performing their duties (according to the last 2 epochs)"
+          content="Validator's status within the SSV network, primarily based on operator performance over the last 2 epochs, with additional context from its Beacon chain state."
         >
           <div className="flex w-fit gap-2 items-center">
             <Text variant="body-2-medium">Status</Text>

--- a/src/components/cluster/cluster-validators-list.tsx
+++ b/src/components/cluster/cluster-validators-list.tsx
@@ -49,14 +49,19 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
           <Text>Public Key</Text>,
           <Tooltip
             asChild
-            content="Refers to the validators status in the SSV network (not beacon chain), and reflects whether its operators are consistently performing their duties (according to the last 2 epochs)"
+            content="Validator's status within the SSV network, primarily based on operator performance over the last 2 epochs, with additional context from its Beacon chain state."
           >
             <div className="flex w-fit gap-2 items-center">
               <Text>Status</Text>
               <FaCircleInfo className="size-3 text-gray-500" />
             </div>
           </Tooltip>,
-          <Text>Effective Balance</Text>,
+          <Tooltip asChild content="Each validator's effective balance according to the beacon chain. Operational runway is calculated from the cluster effective balance reported by the oracles.">
+            <div className="flex items-center gap-1.5">
+              <Text>Effective Balance</Text>
+              <FaCircleInfo className="size-3 text-gray-500" />
+            </div>
+          </Tooltip>,
           null,
         ]}
         items={validators}

--- a/src/components/effective-balance/effective-balance-breakdown-card.tsx
+++ b/src/components/effective-balance/effective-balance-breakdown-card.tsx
@@ -5,6 +5,7 @@ import { Text } from "@/components/ui/text";
 import { numberFormatter } from "@/lib/utils/number";
 import { EffectiveBalanceBreakDownChart } from "./effective-balance-breakdown-chart";
 import { Tooltip } from "@/components/ui/tooltip";
+import { FaCircleInfo } from "react-icons/fa6";
 
 type EffectiveBalanceBreakdownCardProps = {
   clusterHash: string;
@@ -28,9 +29,14 @@ export const EffectiveBalanceBreakdownCard: FC<
   return (
     <Card className="w-full p-6 gap-6">
       <div className="flex items-center justify-between">
-        <Text variant="headline4" className="text-gray-500">
-          Effective Balance
-        </Text>
+        <Tooltip asChild content="Current beacon-chain effective balance for this validator (ETH)">
+          <div className="flex items-center gap-1.5">
+            <Text variant="headline4" className="text-gray-500">
+              Effective Balance
+            </Text>
+            <FaCircleInfo className="size-4 text-gray-500" />
+          </div>
+        </Tooltip>
         {!hasProjected && (
           <Text variant="headline4">
             {numberFormatter.format(effectiveBalance)} ETH
@@ -71,7 +77,7 @@ export const EffectiveBalanceBreakdownCard: FC<
           </Tooltip>
           <Tooltip
             asChild
-            content="Total effective balance of all validators in this cluster, including validators waiting in the deposit queue."
+            content="Total effective balance of all validators in this cluster, including validators waiting in the deposit queue or not yet picked up by the oracles."
           >
             <button
               type="button"

--- a/src/components/effective-balance/effective-balance-breakdown-chart.tsx
+++ b/src/components/effective-balance/effective-balance-breakdown-chart.tsx
@@ -5,6 +5,8 @@ import { StripedBar } from "@/components/ui/striped-bar";
 import { numberFormatter } from "@/lib/utils/number";
 import { useClusterEffectiveBalanceBreakdown } from "@/hooks/cluster/use-cluster-effective-balance-breakdown";
 import type { ValidatorsEffectiveBalanceByClusterResponse } from "@/api/validators";
+import { FaCircleInfo } from "react-icons/fa6";
+import { Tooltip } from "@/components/ui/tooltip";
 
 export type EffectiveBalanceBreakDownChartProps = {
   clusterHash: string;
@@ -16,15 +18,52 @@ type StatusVisualConfig = {
   key: keyof ValidatorsEffectiveBalanceByClusterResponse["effectiveBalance"];
   label: string;
   variant: React.ComponentProps<typeof StripedBar>["variant"];
+  tooltip: string;
 };
 
 const STATUS_CONFIG: StatusVisualConfig[] = [
-  { key: "notDeposited", label: "Not Deposited", variant: "notDeposited" },
-  { key: "pending", label: "Depositing", variant: "depositing" },
-  { key: "deposited", label: "Deposited", variant: "active" },
-  { key: "exiting", label: "Exiting", variant: "exiting" },
-  { key: "exited", label: "Exited", variant: "exited" },
-  { key: "slashed", label: "Slashed", variant: "slashed" },
+  {
+    key: "notDeposited",
+    label: "Not Deposited",
+    variant: "notDeposited",
+    tooltip:
+      "Undeposited on the beacon chain. Minimum 32ETH effective balance applies per validator.",
+  },
+  {
+    key: "pending",
+    label: "Depositing",
+    variant: "depositing",
+    tooltip:
+      "Effective balance of validators in the beacon chain activation queue. Minimum 32ETH effective balance applies per validator.",
+  },
+  {
+    key: "deposited",
+    label: "Deposited",
+    variant: "active",
+    tooltip:
+      "Effective balance of validators with an active deposit on the beacon chain.",
+  },
+  {
+    key: "exiting",
+    label: "Exiting",
+    variant: "exiting",
+    tooltip:
+      "Effective balance of validators that have requested an exit but haven't reached their exit epoch yet.",
+  },
+  {
+    key: "exited",
+    label: "Exited",
+    variant: "exited",
+    tooltip:
+      "Validators that have fully exited the beacon chain. Minimum 32ETH effective balance applies per validator.",
+  },
+  {
+    key: "slashed",
+    label: "Slashed",
+    variant: "slashed",
+    tooltip:
+      "Validators that have been slashed. Minimum 32ETH minimum effective balance applies per validator.",
+  },
 ];
 
 type EffectiveBalanceBreakDownChartFC = FC<
@@ -69,6 +108,11 @@ export const EffectiveBalanceBreakDownChart: EffectiveBalanceBreakDownChartFC =
                 <Text variant="caption-medium" className="text-gray-500">
                   {item.label}
                 </Text>
+                <Tooltip asChild content={item.tooltip}>
+                  <span>
+                    <FaCircleInfo className="size-3 text-gray-400" />
+                  </span>
+                </Tooltip>
               </div>
               <Text variant="caption-bold">
                 {numberFormatter.format(item.amount)} ETH

--- a/src/components/operator/operator-validators-list.tsx
+++ b/src/components/operator/operator-validators-list.tsx
@@ -27,7 +27,7 @@ export const OperatorValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
         <Text>Public key</Text>,
         <Tooltip
           asChild
-          content="Refers to the validators status in the SSV network (not beacon chain), and reflects whether its operators are consistently performing their duties (according to the last 2 epochs)"
+          content="Validator's status within the SSV network, primarily based on operator performance over the last 2 epochs, with additional context from its Beacon chain state."
         >
           <div className="flex w-fit gap-2 items-center">
             <Text>Status</Text>


### PR DESCRIPTION
- Update effective balance tooltip to mention oracles pickup delay
- Update validator status tooltip to reflect Beacon chain context
- Default additional funding step to "No - use current balance"
- Disable Next button when top-up is selected but amount is 0