### PR TITLE
feat: add cluster naming feature

### DIFF
--- a/src/api/cluster.ts
+++ b/src/api/cluster.ts
@@ -94,7 +94,7 @@ export const getPaginatedClusterValidators = (
     }));
 };
 
-export const updateClusterMetadata = (
+export const updateClusterName = (
   clusterId: string,
   payload: { name: string; signature: string },
 ) => {

--- a/src/api/cluster.ts
+++ b/src/api/cluster.ts
@@ -94,6 +94,13 @@ export const getPaginatedClusterValidators = (
     }));
 };
 
+export const updateClusterMetadata = (
+  clusterId: string,
+  payload: { name: string; signature: string },
+) => {
+  return api.put(endpoint(`clusters/${clusterId}/metadata`), payload);
+};
+
 export const getClusterTotalEffectiveBalance = (clusterHash: string) => {
   return api
     .get<{

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-header.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-header.tsx
@@ -1,4 +1,5 @@
 import type { FC, ComponentPropsWithoutRef } from "react";
+import { useState } from "react";
 import { cn } from "@/lib/utils/tw";
 import { Text } from "@/components/ui/text";
 import { Badge } from "@/components/ui/badge";
@@ -7,12 +8,15 @@ import { useClusterPageParams } from "@/hooks/cluster/use-cluster-page-params";
 import { useClusterState } from "@/hooks/cluster/use-cluster-state";
 import { shortenClusterId } from "@/lib/utils/strings";
 import { FaAngleLeft } from "react-icons/fa";
+import { FaPencil } from "react-icons/fa6";
 import { Link } from "react-router-dom";
 import { ClusterOperators } from "./cluster-operators";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Card } from "@/components/ui/card";
 import { OperatorsBreakdownChart } from "@/components/cluster/operators-breakdown-chart";
 import { useOperators } from "@/hooks/operator/use-operators";
+import { ClusterNameDialog } from "./cluster-name-dialog";
+import { useAccount } from "@/hooks/account/use-account";
 
 export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
   className,
@@ -26,7 +30,13 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
   const { data: operators = [] } = useOperators(cluster.data?.operators ?? []);
 
   const clusterId = cluster.data?.clusterId ?? "";
+  const clusterName = cluster.data?.metadata?.name;
   const isLiquidatedCluster = Boolean(isLiquidated.data);
+
+  const { address } = useAccount();
+  const isOwner = address?.toLowerCase() === cluster.data?.ownerAddress?.toLowerCase();
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (
     <Card
@@ -40,33 +50,41 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
         <FaAngleLeft className="size-4 text-primary-500" />
       </Link>
 
-      <div className="flex flex-1 items-center gap-5">
-        <div className="flex items-center gap-2">
-          <Text variant="headline4">Cluster</Text>
+      <div className="flex flex-1 items-center gap-5 min-w-0">
+        <div className="flex items-center gap-2 min-w-0 overflow-hidden">
+          <Text variant="headline4" className="truncate">{clusterName || "Cluster"}</Text>
+          {isOwner && (
+            <button
+              onClick={() => setIsDialogOpen(true)}
+              className="shrink-0 text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <FaPencil className="size-3.5" />
+            </button>
+          )}
         </div>
 
-        <div className="flex flex-1 items-center gap-2.5">
-          <div className="flex flex-1 items-center gap-1 h-6">
-            <div className="flex items-center gap-1 rounded-[6px] bg-gray-100 border border-gray-200 px-2 py-0.5">
-              <Text variant="caption-medium" className="text-gray-500">
-                ID:
-              </Text>
-              <Text
-                variant="body-3-medium"
-                className="font-robotoMono text-gray-700"
-              >
-                {shortenClusterId(clusterId)}
-              </Text>
-              <CopyBtn text={clusterId} />
-            </div>
-
-            {isLiquidatedCluster && (
-              <Badge variant="error" size="xs">
-                Liquidated
-              </Badge>
-            )}
+        <div className="flex shrink-0 items-center gap-1 h-6">
+          <div className="flex items-center gap-1 rounded-[6px] bg-gray-100 border border-gray-200 px-2 py-0.5">
+            <Text variant="caption-medium" className="text-gray-500">
+              ID:
+            </Text>
+            <Text
+              variant="body-3-medium"
+              className="font-robotoMono text-gray-700"
+            >
+              {shortenClusterId(clusterId)}
+            </Text>
+            <CopyBtn text={clusterId} />
           </div>
 
+          {isLiquidatedCluster && (
+            <Badge variant="error" size="xs">
+              Liquidated
+            </Badge>
+          )}
+        </div>
+
+        <div className="ml-auto shrink-0">
           <Tooltip
             className="p-6"
             content={<OperatorsBreakdownChart operators={operators} />}
@@ -75,6 +93,7 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
           </Tooltip>
         </div>
       </div>
+      <ClusterNameDialog clusterId={clusterId} currentName={clusterName} isOpen={isDialogOpen} onOpenChange={setIsDialogOpen} />
     </Card>
   );
 };

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-header.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-header.tsx
@@ -30,7 +30,7 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
   const { data: operators = [] } = useOperators(cluster.data?.operators ?? []);
 
   const clusterId = cluster.data?.clusterId ?? "";
-  const clusterName = cluster.data?.metadata?.name;
+  const clusterName = cluster.data?.name;
   const isLiquidatedCluster = Boolean(isLiquidated.data);
 
   const { address } = useAccount();

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-name-dialog.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-name-dialog.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSignMessage } from "wagmi";
 import { FaXmark } from "react-icons/fa6";
-import { updateClusterMetadata } from "@/api/cluster";
+import { updateClusterName } from "@/api/cluster";
+import { queryClient } from "@/lib/react-query";
 import {
   Dialog,
   DialogClose,
@@ -51,20 +53,46 @@ export const ClusterNameDialog = ({
 }: ClusterNameDialogProps) => {
   const form = useForm({
     mode: "onChange",
-    defaultValues: { name: currentName ?? "" },
+    values: { name: isOpen ? (currentName ?? "") : "" },
     resolver: zodResolver(makeSchema(!!currentName)),
   });
 
-  const { signMessage, isPending } = useSignMessage({
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const { signMessage, isPending: isSigning } = useSignMessage({
     mutation: {
-      onSuccess: (signature) => {
+      onSuccess: async (signature) => {
         const name = form.getValues("name") || clusterId;
-        updateClusterMetadata(clusterId, { name, signature });
-        onOpenChange(false);
-        form.reset();
+        setIsUpdating(true);
+        try {
+          await updateClusterName(clusterId, { name, signature });
+          // Poll until the API reflects the new name
+          const expectedName = name === clusterId ? undefined : name;
+          for (let i = 0; i < 10; i++) {
+            await queryClient.refetchQueries({ queryKey: ["cluster"] });
+            const data = queryClient.getQueriesData<{ name?: string }>({
+              predicate: (query) =>
+                query.queryKey[0] === "cluster" &&
+                query.queryKey[1] === clusterId.toLowerCase(),
+            });
+            const current = data[0]?.[1];
+            if (
+              (expectedName === undefined && !current?.name) ||
+              current?.name === expectedName
+            ) break;
+            await new Promise((r) => setTimeout(r, 1000));
+          }
+          await queryClient.invalidateQueries({ queryKey: ["paginated-my-account-clusters"] });
+          onOpenChange(false);
+          form.reset();
+        } finally {
+          setIsUpdating(false);
+        }
       },
     },
   });
+
+  const isPending = isSigning || isUpdating;
 
   const handleUpdate = form.handleSubmit(({ name }) => {
     signMessage({ message: name || clusterId });
@@ -72,8 +100,6 @@ export const ClusterNameDialog = ({
 
   const handleOpenChange = (open: boolean) => {
     onOpenChange(open);
-    if (open) form.reset({ name: currentName ?? "" });
-    else form.reset();
   };
 
   return (
@@ -109,7 +135,7 @@ export const ClusterNameDialog = ({
                       {field.value && (
                         <button
                           type="button"
-                          onClick={() => field.onChange("")}
+                          onClick={() => form.setValue("name", "", { shouldValidate: true, shouldDirty: true })}
                           className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 hover:text-gray-600 transition-colors"
                         >
                           Clear

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-name-dialog.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-name-dialog.tsx
@@ -1,0 +1,144 @@
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useSignMessage } from "wagmi";
+import { FaXmark } from "react-icons/fa6";
+import { updateClusterMetadata } from "@/api/cluster";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/ui/form";
+
+const makeSchema = (hasExistingName: boolean) =>
+  z.object({
+    name: z
+      .string()
+      .refine(
+        (val) =>
+          hasExistingName ? val === "" || val.length >= 3 : val.length >= 3,
+        "Cluster name must be at least 3 characters",
+      )
+      .refine(
+        (val) => val.length <= 30,
+        "Cluster name must be at most 30 characters",
+      ),
+  });
+
+type ClusterNameDialogProps = {
+  clusterId: string;
+  currentName?: string;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export const ClusterNameDialog = ({
+  clusterId,
+  currentName,
+  isOpen,
+  onOpenChange,
+}: ClusterNameDialogProps) => {
+  const form = useForm({
+    mode: "onChange",
+    defaultValues: { name: currentName ?? "" },
+    resolver: zodResolver(makeSchema(!!currentName)),
+  });
+
+  const { signMessage, isPending } = useSignMessage({
+    mutation: {
+      onSuccess: (signature) => {
+        const name = form.getValues("name") || clusterId;
+        updateClusterMetadata(clusterId, { name, signature });
+        onOpenChange(false);
+        form.reset();
+      },
+    },
+  });
+
+  const handleUpdate = form.handleSubmit(({ name }) => {
+    signMessage({ message: name || clusterId });
+  });
+
+  const handleOpenChange = (open: boolean) => {
+    onOpenChange(open);
+    if (open) form.reset({ name: currentName ?? "" });
+    else form.reset();
+  };
+
+  return (
+    <Dialog isOpen={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="w-[648px] max-w-[648px] gap-6 p-8">
+        <DialogClose className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 transition-colors">
+          <FaXmark className="size-4" />
+        </DialogClose>
+        <DialogHeader className="gap-3">
+          <DialogTitle>Cluster name</DialogTitle>
+          <p className="text-sm text-gray-700">
+            Set a display name for this cluster
+          </p>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={handleUpdate} className="flex flex-col gap-6">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <div className="relative">
+                      <Input
+                        placeholder="Cluster"
+                        {...field}
+                        disabled={isPending}
+                        aria-invalid={
+                          field.value.length > 0 &&
+                          !!form.formState.errors.name
+                        }
+                      />
+                      {field.value && (
+                        <button
+                          type="button"
+                          onClick={() => field.onChange("")}
+                          className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 hover:text-gray-600 transition-colors"
+                        >
+                          Clear
+                        </button>
+                      )}
+                    </div>
+                  </FormControl>
+                  {form.formState.dirtyFields.name &&
+                    field.value.length > 0 && <FormMessage />}
+                </FormItem>
+              )}
+            />
+            <Button
+              type="submit"
+              size="xl"
+              disabled={
+                !form.formState.isDirty ||
+                !form.formState.isValid ||
+                isPending
+              }
+              isLoading={isPending}
+            >
+              Update Details
+            </Button>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+ClusterNameDialog.displayName = "ClusterNameDialog";

--- a/src/components/validator/clusters-table/clusters-table-row.tsx
+++ b/src/components/validator/clusters-table/clusters-table-row.tsx
@@ -61,7 +61,7 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
     >
       <TableCell>
         <div className="max-w-[88px] truncate">
-          {resolvedCluster.metadata?.name || shortenClusterId(cluster.clusterId)}
+          {resolvedCluster.name || shortenClusterId(cluster.clusterId)}
         </div>
       </TableCell>
       <TableCell>

--- a/src/components/validator/clusters-table/clusters-table-row.tsx
+++ b/src/components/validator/clusters-table/clusters-table-row.tsx
@@ -59,7 +59,11 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
       })}
       {...props}
     >
-      <TableCell>{shortenClusterId(cluster.clusterId)}</TableCell>
+      <TableCell>
+        <div className="max-w-[88px] truncate">
+          {resolvedCluster.metadata?.name || shortenClusterId(cluster.clusterId)}
+        </div>
+      </TableCell>
       <TableCell>
         <div className="flex gap-[2px]">
           {cluster.operators.map((o) => {

--- a/src/components/validator/clusters-table/clusters-table.tsx
+++ b/src/components/validator/clusters-table/clusters-table.tsx
@@ -113,7 +113,7 @@ export const ClusterTable: FCProps = ({
               content={
                 <>
                   Clusters represent a unique set of operators who operate your
-                  validators.{" "}
+                  validators and can be represented by ID or a name.{" "}
                   <Button
                     as={Link}
                     to={links.MORE_ON_CLUSTERS}
@@ -129,7 +129,7 @@ export const ClusterTable: FCProps = ({
                 type: "id",
                 title: (
                   <span className="flex gap-2 items-center">
-                    <span>Cluster ID</span>
+                    <span>Cluster</span>
                     <FaCircleInfo className="size-3 text-gray-500" />
                   </span>
                 ),

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -189,7 +189,7 @@ export type Cluster<
     createdAt: string;
     updatedAt: string;
     migrated?: boolean;
-    metadata?: { name?: string };
+    name?: string;
   } & T
 >;
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -189,6 +189,7 @@ export type Cluster<
     createdAt: string;
     updatedAt: string;
     migrated?: boolean;
+    metadata?: { name?: string };
   } & T
 >;
 


### PR DESCRIPTION
- Add pencil icon in cluster header (owner only) to open rename dialog
- Dialog with name input, validation (3-30 chars), Clear button
- Sign name via MetaMask, call PUT /clusters/:id/metadata
- Show cluster name in header and dashboard table (with truncation/ellipsis)
- Remove Name flow when clearing existing name
- Rename "Cluster ID" column to "Cluster" with updated tooltip
- Operators always pinned to right edge of header