### PR TITLE
chore(qa): add data-testid to shared UI composites (PR 1/7)

### DIFF
--- a/TEST_IDS.md
+++ b/TEST_IDS.md
@@ -1,0 +1,134 @@
+# Test IDs Reference
+
+Stable selectors for QA automation against the SSV web app. Every interactive element and key value display in the app has a `data-testid` attribute that test frameworks (Playwright, Cypress, Testing Library) can target.
+
+## Conventions
+
+**Attribute:** `data-testid` only. Do not use `id`, `data-qa`, `data-cy`, or other variants.
+
+**Naming:** `page-section-element-action` kebab-case. Examples:
+- `dashboard-validator-list-row-remove-btn`
+- `create-cluster-step1-operator-search-input`
+- `switch-wizard-confirm-btn`
+
+**Scope tagged across the app:**
+- Every interactive element: `<button>`, `<a>`, `<input>`, `<select>`, `<textarea>`, `<Tab>`, `<Toggle>`, `<Checkbox>`, `<Radio>`
+- Page headings (`<h1>`, `<h2>`)
+- Status/value displays: balances, validator counts, fees, APR %, network selectors, cluster health badges
+- Error messages, toast messages, banner text
+- Modal titles + action buttons
+- Form field labels (for locate-by-label selectors)
+- Table column headers + entity row identifiers
+
+**Dynamic lists** carry three attributes per row:
+- `data-testid="<page>-<entity>-row"` (general selector for "any row in this list")
+- `data-testid-index="<n>"` (positional, 0-indexed)
+- `data-testid-entity="<id>"` (stable entity identifier — validator pubkey, operator ID, cluster hash)
+
+## Shared component contract
+
+Most shared components in `src/components/ui/` are shadcn-style: they spread props onto their underlying interactive element. You can pass `data-testid` directly at the call site:
+
+```tsx
+<Button data-testid="dashboard-create-cluster-btn">Create Cluster</Button>
+<Input data-testid="create-cluster-search-input" />
+<Checkbox data-testid="terms-checkbox" />
+<Switch data-testid="dark-mode-toggle" />
+<CopyBtn data-testid="cluster-hash-copy-btn" text={hash} />
+```
+
+These components automatically forward `data-testid` to the testable DOM element: **Button**, **IconButton**, **Input**, **NumberInput**, **BigNumberInput**, **SearchInput**, **Checkbox**, **Switch**, **Dialog\***, **AlertDialog\***, **Tab\***, **CopyBtn**, **NavigateBackBtn**, **SsvExplorerBtn**, **BeaconchainBtn**.
+
+### Composites with baked-in test IDs
+
+Some shared components have internal interactive elements that call sites can't reach. These ship with fixed IDs:
+
+| Component | Element | Test ID |
+| --- | --- | --- |
+| `Pagination` | Container `<nav>` | `pagination-nav` |
+| `Pagination` | Previous page button | `pagination-prev-btn` |
+| `Pagination` | Next page button | `pagination-next-btn` |
+| `Pagination` | Page N button | `pagination-page-{N}-btn` (1-indexed) |
+| `Pagination` | Ellipsis | `pagination-ellipsis` |
+| `Toast` | Root toast container | `toast` |
+| `Toast` | Close button | `toast-close-btn` |
+| `Toast` | Title | `toast-title` |
+| `Toast` | Description | `toast-description` |
+| `TransactionModal` | Dialog root | `transaction-modal` |
+| `TransactionModal` | Title ("Sending Transaction") | `transaction-modal-title` |
+| `TransactionModal` | Description | `transaction-modal-description` |
+| `TransactionModal` | Pending step | `transaction-modal-pending-step` |
+| `TransactionModal` | Indexing step | `transaction-modal-indexing-step` |
+| `TransactionModal` | Transaction hash text | `transaction-modal-tx-hash` |
+| `TransactionModal` | Copy hash button | `transaction-modal-copy-tx-hash-btn` |
+| `TransactionModal` | View transaction link | `transaction-modal-view-tx-link` |
+| `MultisigTransactionModal` | Dialog root | `multisig-transaction-modal` |
+| `MultisigTransactionModal` | Title | `multisig-transaction-modal-title` |
+| `MultisigTransactionModal` | Description | `multisig-transaction-modal-description` |
+| `MultisigTransactionModal` | Close button | `multisig-transaction-modal-close-btn` |
+| `ClusterBackBtnHeader` | Root container | `cluster-back-btn-header` |
+| `ClusterBackBtnHeader` | Cluster hash text | `cluster-back-btn-header-cluster-hash` |
+| `ClusterBackBtnHeader` | Copy hash button | `cluster-back-btn-header-copy-cluster-hash-btn` |
+| `JSONFileUploader` | Dropzone | `json-file-uploader-dropzone` |
+| `JSONFileUploader` | Empty/prompt text | `json-file-uploader-empty-prompt` |
+| `JSONFileUploader` | Loading text | `json-file-uploader-loading` |
+| `JSONFileUploader` | Error text | `json-file-uploader-error` |
+| `JSONFileUploader` | File name text | `json-file-uploader-file-{i}-name` |
+| `JSONFileUploader` | Remove button | `json-file-uploader-remove-btn` |
+| `FileUploaderItem` | Remove button | `file-uploader-item-{index}-remove-btn` |
+
+### Components that accept a `data-testid` prop explicitly
+
+These components don't spread arbitrary props but accept `data-testid` directly:
+
+| Component | Notes |
+| --- | --- |
+| `ExpandButton` | Pass `data-testid="..."` — applied to the underlying icon button. |
+
+## Per-page test ID manifest
+
+Tagged page-by-page in subsequent PRs.
+
+### Dashboard
+
+_To be populated in PR 2._
+
+### Create cluster wizard
+
+_To be populated in PR 3._
+
+### Switch wizard (SSV → ETH migration)
+
+_To be populated in PR 4._
+
+### Join (operator onboarding)
+
+_To be populated in PR 5._
+
+### Reshare DKG
+
+_To be populated in PR 6._
+
+### Modals + banners + remaining
+
+_To be populated in PR 7._
+
+## Adding test IDs to new code
+
+When adding any new UI to this repo:
+
+1. **Native HTML elements** — add `data-testid` directly.
+2. **Shared components** — pass `data-testid="..."` at the call site. It will forward to the testable DOM element automatically.
+3. **New shared components** — accept `data-testid` via prop spread. If the component has internal interactive children, give each a derived ID (e.g. `${testId}-confirm-btn`) and document it in this file.
+4. **Lists / repeating rows** — add all three attributes: `data-testid="<page>-<entity>-row"`, `data-testid-index="<n>"`, `data-testid-entity="<id>"`.
+
+## Verifying coverage
+
+To find untagged interactive elements on a page:
+
+```bash
+grep -rE '<(button|input|select|textarea|a)\b' src/app/routes/<page>/ \
+  | grep -v 'data-testid'
+```
+
+Treat any match as a gap and tag before merging UI changes.

--- a/src/components/ui/cluster-back-btn-header.tsx
+++ b/src/components/ui/cluster-back-btn-header.tsx
@@ -7,12 +7,16 @@ export const ClusterBackBtnHeader = () => {
   const { clusterHash } = useClusterPageParams();
 
   return (
-    <div className="flex gap-4">
+    <div data-testid="cluster-back-btn-header" className="flex gap-4">
       Cluster {shortenAddress((clusterHash || "").slice(2) || "", 4, 4)}
       <div className="h-6 w-[1px] bg-gray-400" />
-      <Text className="text-gray-700 font-medium flex items-center gap-4">
+      <Text
+        data-testid="cluster-back-btn-header-cluster-hash"
+        className="text-gray-700 font-medium flex items-center gap-4"
+      >
         {shortenAddress((clusterHash || "").slice(2) || "", 4, 4)}
         <CopyBtn
+          data-testid="cluster-back-btn-header-copy-cluster-hash-btn"
           isFullSizeIcon
           text={clusterHash}
           className="bg-transparent text-[24px] size-[24px] p-0"

--- a/src/components/ui/expand-button.tsx
+++ b/src/components/ui/expand-button.tsx
@@ -5,12 +5,15 @@ import { IconButton } from "@/components/ui/button.tsx";
 const ExpandButton = ({
   setIsOpen,
   isOpen,
+  "data-testid": testId,
 }: {
   setIsOpen: (isOpen: boolean) => void;
   isOpen: boolean;
+  "data-testid"?: string;
 }) => {
   return (
     <IconButton
+      data-testid={testId}
       variant="ghost"
       className="size-9 p-[2px] hover:bg-primary-100 hover:text-primary-500"
       onClick={(ev) => {

--- a/src/components/ui/file-upload.tsx
+++ b/src/components/ui/file-upload.tsx
@@ -307,6 +307,7 @@ export const FileUploaderItem = forwardRef<
       </div>
       <button
         type="button"
+        data-testid={`file-uploader-item-${index}-remove-btn`}
         className={cn(
           "absolute",
           direction === "rtl" ? "top-1 left-1" : "top-1 right-1",
@@ -399,7 +400,10 @@ export const JSONFileUploader = ({
       value={files}
       onValueChange={onValueChange}
     >
-      <FileInput className="h-64 flex flex-col items-center justify-center bg-gray-100 border border-gray-300 rounded-xl">
+      <FileInput
+        data-testid="json-file-uploader-dropzone"
+        className="h-64 flex flex-col items-center justify-center bg-gray-100 border border-gray-300 rounded-xl"
+      >
         <div className="flex flex-col items-center gap-4">
           {isLoading ? (
             <div className="size-12">
@@ -414,11 +418,19 @@ export const JSONFileUploader = ({
             />
           )}
           {isLoading && loadingText ? (
-            <Text variant="body-2-medium" className="text-gray-500">
+            <Text
+              data-testid="json-file-uploader-loading"
+              variant="body-2-medium"
+              className="text-gray-500"
+            >
               {loadingText}
             </Text>
           ) : !files.length ? (
-            <Text variant="body-2-medium" className="text-gray-500">
+            <Text
+              data-testid="json-file-uploader-empty-prompt"
+              variant="body-2-medium"
+              className="text-gray-500"
+            >
               Drag and drop files or{" "}
               <Span className="text-primary-500">browse</Span>
             </Text>
@@ -426,6 +438,7 @@ export const JSONFileUploader = ({
             <>
               {isError && error ? (
                 <Text
+                  data-testid="json-file-uploader-error"
                   variant="body-2-medium"
                   className="text-red-500 text-center max-w-96"
                 >
@@ -437,6 +450,7 @@ export const JSONFileUploader = ({
                     files.length > 0 &&
                     files.map((file, i) => (
                       <Text
+                        data-testid={`json-file-uploader-file-${i}-name`}
                         variant="body-2-medium"
                         className={cn("text-success-500", {
                           "text-error-500": isError,
@@ -451,6 +465,7 @@ export const JSONFileUploader = ({
               )}
 
               <Button
+                data-testid="json-file-uploader-remove-btn"
                 variant="link"
                 onClick={(ev) => {
                   ev.preventDefault();

--- a/src/components/ui/multisig-transaction-modal.tsx
+++ b/src/components/ui/multisig-transaction-modal.tsx
@@ -35,12 +35,18 @@ export const MultisigTransactionModal: FCProps = () => {
       };
   return (
     <Dialog isOpen={isOpen}>
-      <DialogContent className="flex bg-gray-50 flex-col gap-8 max-w-[424px] font-medium ">
+      <DialogContent
+        data-testid="multisig-transaction-modal"
+        className="flex bg-gray-50 flex-col gap-8 max-w-[424px] font-medium "
+      >
         <div className="flex flex-col gap-3">
-          <DialogTitle>
+          <DialogTitle data-testid="multisig-transaction-modal-title">
             <Text variant="headline4">Transaction Initiated</Text>
           </DialogTitle>
-          <Text variant="body-2-medium">
+          <Text
+            data-testid="multisig-transaction-modal-description"
+            variant="body-2-medium"
+          >
             Your transaction has been successfully initiated within the
             multi-sig wallet and is now pending approval from other
             participants.
@@ -50,7 +56,12 @@ export const MultisigTransactionModal: FCProps = () => {
           </Text>
         </div>
         <img src="/images/ssv-loader.svg" className="size-28 mx-auto" />
-        <Button {...(buttonProps as ButtonProps)}>Close</Button>
+        <Button
+          data-testid="multisig-transaction-modal-close-btn"
+          {...(buttonProps as ButtonProps)}
+        >
+          Close
+        </Button>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -15,6 +15,7 @@ const PaginationContainer = ({
   <nav
     role="navigation"
     aria-label="pagination"
+    data-testid="pagination-nav"
     className={cn("mx-auto flex w-full justify-center", className)}
     {...props}
   />
@@ -72,7 +73,11 @@ PaginationLink.displayName = "PaginationLink";
 const PaginationPrevious = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink aria-label="Go to previous page" {...props}>
+  <PaginationLink
+    aria-label="Go to previous page"
+    data-testid="pagination-prev-btn"
+    {...props}
+  >
     <ChevronLeft className="size-4" />
   </PaginationLink>
 );
@@ -81,7 +86,11 @@ PaginationPrevious.displayName = "PaginationPrevious";
 const PaginationNext = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink aria-label="Go to next page" {...props}>
+  <PaginationLink
+    aria-label="Go to next page"
+    data-testid="pagination-next-btn"
+    {...props}
+  >
     <ChevronRight className="size-4" />
   </PaginationLink>
 );
@@ -93,6 +102,7 @@ const PaginationEllipsis = ({
 }: React.ComponentProps<"span">) => (
   <span
     aria-hidden
+    data-testid="pagination-ellipsis"
     className={cn("flex h-9 w-9 items-center justify-center", className)}
     {...props}
   >
@@ -132,6 +142,7 @@ const Pagination: React.FC<React.ComponentProps<"nav"> & PaginationProps> = ({
             <PaginationLink
               to={{ search: buildSearch(i + 1) }}
               isActive={i + 1 === pagination.page}
+              data-testid={`pagination-page-${i + 1}-btn`}
             >
               {i + 1}
             </PaginationLink>

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -46,6 +46,7 @@ const Toast = React.forwardRef<
   return (
     <ToastPrimitives.Root
       ref={ref}
+      data-testid="toast"
       className={cn(toastVariants({ variant }), className)}
       {...props}
     />
@@ -74,6 +75,7 @@ const ToastClose = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Close
     ref={ref}
+    data-testid="toast-close-btn"
     className={cn(
       "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className,
@@ -92,6 +94,7 @@ const ToastTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Title
     ref={ref}
+    data-testid="toast-title"
     className={cn("text-sm font-semibold", className)}
     {...props}
   />
@@ -104,6 +107,7 @@ const ToastDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Description
     ref={ref}
+    data-testid="toast-description"
     className={cn("text-sm opacity-90 break-words", className)}
     style={{
       wordBreak: "break-word",

--- a/src/components/ui/transaction-modal.tsx
+++ b/src/components/ui/transaction-modal.tsx
@@ -37,17 +37,28 @@ export const TransactionModal: FCProps = () => {
 
   return (
     <Dialog isOpen={isOpen}>
-      <DialogContent className="flex bg-gray-50 flex-col gap-8 max-w-[424px] font-medium ">
+      <DialogContent
+        data-testid="transaction-modal"
+        className="flex bg-gray-50 flex-col gap-8 max-w-[424px] font-medium "
+      >
         <div className="flex flex-col gap-3">
-          <DialogTitle>
+          <DialogTitle data-testid="transaction-modal-title">
             <Text variant="headline4">Sending Transaction</Text>
           </DialogTitle>
-          <Text variant="body-2-medium">{description}</Text>
+          <Text
+            data-testid="transaction-modal-description"
+            variant="body-2-medium"
+          >
+            {description}
+          </Text>
         </div>
         <img src={loaderSrc} className="size-28 mx-auto" />
         {isTwoStep && (
           <div className="flex  w-[244px] mx-auto">
-            <div className="flex flex-col items-center gap-1">
+            <div
+              data-testid="transaction-modal-pending-step"
+              className="flex flex-col items-center gap-1"
+            >
               <StepperDot
                 className=""
                 disabled={isIndexing}
@@ -64,7 +75,10 @@ export const TransactionModal: FCProps = () => {
               </Text>
             </div>
             <Divider className="flex-1 mt-3" />
-            <div className="flex flex-col items-center gap-1">
+            <div
+              data-testid="transaction-modal-indexing-step"
+              className="flex flex-col items-center gap-1"
+            >
               <StepperDot
                 disabled={isPending}
                 variant={isPending || isIndexing ? "active" : "done"}
@@ -91,15 +105,21 @@ export const TransactionModal: FCProps = () => {
             </Text>
             <div className="flex items-center h-[50px] px-5 pr-2 py-3 border border-gray-300 rounded-xl">
               <Text
+                data-testid="transaction-modal-tx-hash"
                 variant="body-2-medium"
                 className="flex-1 text-ellipsis overflow-hidden mr-3"
               >
                 {meta.hash}
               </Text>
-              <CopyBtn text={meta.hash} className="size-8" />
+              <CopyBtn
+                data-testid="transaction-modal-copy-tx-hash-btn"
+                text={meta.hash}
+                className="size-8"
+              />
             </div>
           </div>
           <Button
+            data-testid="transaction-modal-view-tx-link"
             as="a"
             target="_blank"
             variant="link"


### PR DESCRIPTION
## Summary

First PR in a 7-PR series adding `data-testid` attributes across the ssv-web app so QA can build automated test suites against staging.

This PR only touches `src/components/ui/` and lays the foundation:
- Adds baked-in test IDs to **composite components** whose internal interactive elements can't be reached by call-site prop spread (Pagination, Toast, TransactionModal, MultisigTransactionModal, ClusterBackBtnHeader, JSONFileUploader, FileUploaderItem).
- Adds an explicit `data-testid` prop to **ExpandButton** (which has no prop spread).
- Verifies the rest of the shared UI library (Button, Input, Checkbox, Switch, Dialog, AlertDialog, Tabs, CopyBtn, etc.) already forwards `data-testid` via `{...props}` — so subsequent PRs can pass IDs at the call site with zero shared-component churn.
- Adds **`TEST_IDS.md`** at the repo root: conventions, shared-component contract, manifest of baked-in IDs added here, and placeholders for per-page IDs to be filled in by PRs 2–7.

No call-site changes in this PR; no behavior changes.

## Conventions (full detail in TEST_IDS.md)

- Attribute: `data-testid` (kebab-case, hierarchical: `page-section-element-action`)
- Lists carry three attributes: `data-testid="<page>-<entity>-row"`, `data-testid-index="<n>"`, `data-testid-entity="<id>"`
- New shared components must accept `data-testid` via prop spread or derive IDs from a passed-in prop

## Follow-up PRs

- PR 2: Dashboard pages
- PR 3: Create-cluster wizard
- PR 4: Switch-wizard
- PR 5: Join (operator onboarding)
- PR 6: Reshare-DKG
- PR 7: Modals + banners + remaining

## Test plan

- [ ] `pnpm type-check` passes (verified locally)
- [ ] `pnpm lint` passes — no new warnings (verified locally; 1 pre-existing warning unrelated)
- [ ] Visual smoke check on stage deploy — no UI regressions in pagination, toasts, transaction modal flows, file uploader
- [ ] Spot-check DOM: `document.querySelectorAll('[data-testid]')` returns the new tagged elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)