### PR TITLE
chore(qa): add data-testid to dashboard pages (PR 2/7)

### DIFF
--- a/TEST_IDS.md
+++ b/TEST_IDS.md
@@ -91,7 +91,145 @@ Tagged page-by-page in subsequent PRs.
 
 ### Dashboard
 
-_To be populated in PR 2._
+#### Clusters list (`/clusters`)
+
+| Element | Test ID |
+| --- | --- |
+| Page container | `dashboard-clusters-page` |
+| Fee address button | `dashboard-clusters-fee-address-btn` |
+| Add cluster button | `dashboard-clusters-add-cluster-btn` |
+| Empty-state container | `dashboard-clusters-empty-state` |
+| Empty-state message | `dashboard-clusters-empty-message` |
+| Empty-state create button | `dashboard-clusters-empty-create-btn` |
+| Clusters table wrapper | `dashboard-clusters-table` |
+| Headers (sortable) | `dashboard-clusters-table-header-{cluster,operators,validators,effective-balance,cluster-balance,operational-runway}` |
+| Header more-link | `dashboard-clusters-table-header-cluster-more-link` |
+| Row | `dashboard-clusters-table-row` + `data-testid-index={n}` + `data-testid-entity={clusterHash}` |
+| Row cells | `dashboard-clusters-table-row-{name,operators,validators-count,effective-balance,balance,runway,status}` |
+| Row badges | `dashboard-clusters-table-row-{liquidated-badge,low-runway-badge}` |
+| Row switch-to-ETH | `dashboard-clusters-table-row-switch-to-eth-btn` |
+
+#### Operators list (`/operators`)
+
+| Element | Test ID |
+| --- | --- |
+| Page container | `dashboard-operators-page` |
+| Add operator button | `dashboard-operators-add-operator-btn` |
+| Operators table wrapper | `dashboard-operators-table` |
+| Headers | `dashboard-operators-table-header-{name,status,performance,balance,yearly-fee,validators,effective-balance}` |
+| Row | `dashboard-operators-table-row` + `data-testid-index={n}` + `data-testid-entity={operatorId}` |
+| Row cells | `dashboard-operators-table-row-{name,status,performance,balance(-eth/-ssv),yearly-fee(-eth/-ssv),validators-count,effective-balance}` |
+
+#### Dashboard picker (header dropdown)
+
+| Element | Test ID |
+| --- | --- |
+| Trigger | `dashboard-picker-trigger` |
+| Label | `dashboard-picker-label` |
+| Items | `dashboard-picker-item-clusters`, `dashboard-picker-item-operators` |
+
+#### Cluster detail — SSV cluster (`/clusters/:id`)
+
+| Element | Test ID |
+| --- | --- |
+| Page | `dashboard-cluster-page` |
+| Operator stats grid | `dashboard-cluster-operators-stats` |
+| Balance card | `dashboard-cluster-balance-card`, `-label`, `-display` |
+| Liquidated badge | `dashboard-cluster-liquidated-badge` |
+| Action buttons | `dashboard-cluster-{reactivate,switch-to-eth,deposit,withdraw,add-validator}-btn` |
+| Validators card | `dashboard-cluster-validators-card`, `-label`, `-count` |
+
+#### Cluster detail — Migrated/ETH cluster
+
+| Element | Test ID |
+| --- | --- |
+| Page | `dashboard-migrated-cluster-page` |
+| Tabs | `dashboard-migrated-cluster-tab-{validators,operators}` |
+| Add validator | `dashboard-migrated-cluster-add-validator-btn` |
+| Header | `dashboard-migrated-cluster-header`, `-back-link`, `-name`, `-edit-name-btn`, `-id`, `-id-copy-btn`, `-liquidated-badge` |
+| Validators list | `dashboard-cluster-validators-list` |
+| Validator row | `dashboard-cluster-validators-row` + `data-testid-index={n}` + `data-testid-entity={pubkey}` |
+| Validator row cells | `dashboard-cluster-validators-row-{pubkey,pubkey-copy-btn,status,explorer-btn,beaconchain-btn}` |
+| Validator row actions menu | `dashboard-cluster-validators-row-actions-trigger`, `-change-operators-item`, `-remove-item`, `-exit-item` |
+| Operators table | `dashboard-cluster-operators-table` |
+| Operators table headers | `dashboard-cluster-operators-table-header-{name,status,performance,fee}` |
+| Operators table row | `dashboard-cluster-operators-table-row` + `data-testid-index={n}` + `data-testid-entity={operatorId}` |
+| Operators row cells | `dashboard-cluster-operators-table-row-{name,verified-icon,explorer-btn,id,id-copy-btn,status,performance,fee}` |
+
+#### Cluster name dialog
+
+| Element | Test ID |
+| --- | --- |
+| Dialog parts | `cluster-name-dialog`, `-close-btn`, `-title`, `-description`, `-name-input`, `-clear-btn`, `-name-error`, `-api-error`, `-submit-btn` |
+
+#### Operational Runway card
+
+| Element | Test ID |
+| --- | --- |
+| Card | `dashboard-operational-runway-card` |
+| Label / days | `dashboard-operational-runway-label`, `-days` |
+| Action buttons | `dashboard-operational-runway-{deposit,withdraw,reactivate}-btn` |
+
+#### Deposit cluster (`/clusters/:id/deposit`)
+
+`dashboard-cluster-deposit-{page,back-btn,title,amount-input,wallet-balance,submit-btn}`
+
+#### Withdraw cluster (`/clusters/:id/withdraw`)
+
+`dashboard-cluster-withdraw-{page,back-btn,title,available-balance,amount-input,max-btn,liquidation-warning,penalties-link,liquidation-docs-link,agreement-checkbox,submit-btn}`
+
+#### Bulk select validators (exit/remove)
+
+`dashboard-cluster-bulk-{exit|remove}-{page,back-btn,title,selected-count,select-all-checkbox,next-btn}`
+Per row: `…-row` + `data-testid-index` + `data-testid-entity` + per-cell `…-row-{checkbox,pubkey,pubkey-copy-btn,status,explorer-btn,beaconchain-btn}`
+
+#### Exit confirmation
+
+`dashboard-cluster-exit-{confirmation-page,back-btn,queue-info,warning,agree-1-checkbox,agree-2-checkbox,agree-3-checkbox,submit-btn}`
+
+#### Exit success
+
+`dashboard-cluster-exit-success-{page,next-steps-heading,go-to-cluster-btn}`
+
+#### Remove validators confirmation
+
+`dashboard-cluster-remove-{confirmation-page,back-btn,warning,agreement-checkbox,submit-btn}`
+
+#### Fee Recipient (`/fee-recipient`)
+
+`dashboard-fee-recipient-{page,back-btn,proposal-rewards-link,warning,address-label,address-input,address-error,update-btn}`
+
+#### Operator detail (`/operators/:id`)
+
+`dashboard-operator-{page,back-btn,validators-count,performance,effective-balance,balance-card,balance-label,balance-eth,balance-ssv,withdraw-btn,fee-card,fee-label,yearly-fee-eth,yearly-fee-ssv,update-fee-btn,validators-card,validators-label}`
+
+#### Operator settings (`/operators/:id/settings/*`)
+
+| Page | Test ID prefix |
+| --- | --- |
+| Settings root | `dashboard-operator-settings-{page,back-btn,card}` |
+| Metadata | `dashboard-operator-metadata-{page,back-btn,name-input,description-input,setup-provider-input,website-input,twitter-input,linkedin-input,dkg-address-input,submit-btn}` |
+| Authorized addresses | `dashboard-authorized-addresses-{page,back-btn,title,count-badge,input-{i},remove-{i}-btn,add-btn,cancel-btn,submit-btn}` |
+| External contract | `dashboard-external-contract-{page,back-btn,input,clear-btn,cancel-btn,save-btn}` |
+| Operator status | `dashboard-operator-status-{page,back-btn,title,toggle-btn}` |
+
+#### Operator update-fee (`/operators/:id/fee/*`)
+
+| Page | Test IDs |
+| --- | --- |
+| Update root | `dashboard-update-fee-{page,back-btn,yearly-fee-input,max-btn,next-btn}` |
+| Decrease | `dashboard-decrease-fee-{page,back-btn,submit-btn}` |
+| Increase | `dashboard-increase-fee-{page,back-btn,declare-btn,declare-new-btn,cancel-btn,execute-btn,back-to-account-btn}` |
+| Updated success | `dashboard-fee-updated-{page,back-to-account-btn}` |
+
+#### Operator withdraw + remove + error states
+
+| Page | Test IDs |
+| --- | --- |
+| Withdraw operator balance | `dashboard-withdraw-operator-{page,back-btn,balance-eth,balance-ssv,submit-btn}` |
+| Remove operator | `dashboard-remove-operator-{page,back-btn,warning,agreement-checkbox,submit-btn}` |
+| Not your operator | `dashboard-no-your-operator-{page,title,description,back-btn}` |
+| Operator not found | `dashboard-operator-not-found-{page,title,description,back-btn}` |
 
 ### Create cluster wizard
 

--- a/src/app/routes/dashboard/clusters/cluster/bulk.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/bulk.tsx
@@ -55,16 +55,31 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
 
   // TODO: fetch validators to get status
   return (
-    <Container variant="vertical" size="lg" className="py-6 h-full">
-      <NavigateBackBtn to={`/clusters/${clusterHash}`} persistSearch />
+    <Container
+      data-testid={`dashboard-cluster-bulk-${type}-page`}
+      variant="vertical"
+      size="lg"
+      className="py-6 h-full"
+    >
+      <NavigateBackBtn
+        data-testid={`dashboard-cluster-bulk-${type}-back-btn`}
+        to={`/clusters/${clusterHash}`}
+        persistSearch
+      />
       <Card className="w-full flex-1 flex flex-col gap-4">
         <div className="flex justify-between">
-          <Text variant="headline4">
+          <Text
+            data-testid={`dashboard-cluster-bulk-${type}-title`}
+            variant="headline4"
+          >
             {type === "remove"
               ? "Select validators to Remove"
               : "Select validators to Exit"}
           </Text>
-          <Badge variant="primary">
+          <Badge
+            data-testid={`dashboard-cluster-bulk-${type}-selected-count`}
+            variant="primary"
+          >
             {selectedPublicKeys.length} of {totalValidators} selected
           </Badge>
         </div>
@@ -76,6 +91,7 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
           headers={[
             <div className="size-5">
               <Checkbox
+                data-testid={`dashboard-cluster-bulk-${type}-select-all-checkbox`}
                 checked={isAllChecked}
                 onClick={() => {
                   if (!isAllChecked) {
@@ -103,6 +119,9 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
           renderRow={({ index, item }) => (
             <TableRow
               as="label"
+              data-testid={`dashboard-cluster-bulk-${type}-row`}
+              data-testid-index={index}
+              data-testid-entity={item.public_key}
               className="select-none cursor-pointer"
               htmlFor={item.public_key}
               key={index}
@@ -110,6 +129,7 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
             >
               <TableCell className="flex gap-2 items-center">
                 <Checkbox
+                  data-testid={`dashboard-cluster-bulk-${type}-row-checkbox`}
                   id={item.public_key}
                   checked={selectedPublicKeys.includes(item.public_key)}
                   onCheckedChange={() =>
@@ -121,17 +141,32 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
                 />
               </TableCell>
               <TableCell className="flex gap-2 items-center">
-                <Text variant="body-2-medium">
+                <Text
+                  data-testid={`dashboard-cluster-bulk-${type}-row-pubkey`}
+                  variant="body-2-medium"
+                >
                   {shortenAddress(add0x(item.public_key))}
                 </Text>
-                <CopyBtn variant="subtle" text={item.public_key} />
+                <CopyBtn
+                  data-testid={`dashboard-cluster-bulk-${type}-row-pubkey-copy-btn`}
+                  variant="subtle"
+                  text={item.public_key}
+                />
               </TableCell>
               <TableCell>
-                <ValidatorStatusBadge size="sm" status={item.displayedStatus} />
+                <ValidatorStatusBadge
+                  data-testid={`dashboard-cluster-bulk-${type}-row-status`}
+                  size="sm"
+                  status={item.displayedStatus}
+                />
               </TableCell>
               <TableCell className="flex gap-1 justify-end">
-                <SsvExplorerBtn validatorId={item.public_key} />
+                <SsvExplorerBtn
+                  data-testid={`dashboard-cluster-bulk-${type}-row-explorer-btn`}
+                  validatorId={item.public_key}
+                />
                 <Button
+                  data-testid={`dashboard-cluster-bulk-${type}-row-beaconchain-btn`}
                   as="a"
                   size="icon"
                   className="size-7 text-gray-700"
@@ -146,6 +181,7 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
           )}
         />
         <Button
+          data-testid={`dashboard-cluster-bulk-${type}-next-btn`}
           as={Link}
           to={`/clusters/${clusterHash}/${type}/confirmation`}
           size="xl"

--- a/src/app/routes/dashboard/clusters/cluster/cluster.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/cluster.tsx
@@ -62,8 +62,16 @@ export const Cluster: FC = () => {
         backRoutePath="/clusters"
         backButtonLabel="Cluster Details"
       />
-      <Container variant="vertical" size="xl" className="min-h-full py-6">
-        <div className="grid grid-cols-4 gap-6 w-full">
+      <Container
+        data-testid="dashboard-cluster-page"
+        variant="vertical"
+        size="xl"
+        className="min-h-full py-6"
+      >
+        <div
+          data-testid="dashboard-cluster-operators-stats"
+          className="grid grid-cols-4 gap-6 w-full"
+        >
           {cluster.data?.operators.map((operator) => (
             <OperatorStatCard
               isClusterMigrated={isMigrated}
@@ -74,18 +82,33 @@ export const Cluster: FC = () => {
           ))}
         </div>
         <div className="flex flex-1 items-start gap-6 w-full">
-          <Card className="flex-[1]">
+          <Card data-testid="dashboard-cluster-balance-card" className="flex-[1]">
             <div className="flex flex-col gap-2 ">
               <div className="flex gap-2 items-center">
-                <Text variant="headline4" className="text-gray-500">
+                <Text
+                  data-testid="dashboard-cluster-balance-label"
+                  variant="headline4"
+                  className="text-gray-500"
+                >
                   Balance
                 </Text>
-                {isLiquidated.data && <Badge variant="error">Liquidated</Badge>}
+                {isLiquidated.data && (
+                  <Badge
+                    data-testid="dashboard-cluster-liquidated-badge"
+                    variant="error"
+                  >
+                    Liquidated
+                  </Badge>
+                )}
               </div>
               {balance.isLoading ? (
                 <Skeleton className="h-10 w-24 my-1" />
               ) : (
-                <BalanceDisplay amount={balance.data} token={balance.token} />
+                <BalanceDisplay
+                  data-testid="dashboard-cluster-balance-display"
+                  amount={balance.data}
+                  token={balance.token}
+                />
               )}
             </div>
             {Boolean(cluster.data?.validatorCount) && (
@@ -105,11 +128,17 @@ export const Cluster: FC = () => {
 
             {isLiquidated.data ? (
               isMigrated ? (
-                <Button as={Link} to="reactivate-balance" size="xl">
+                <Button
+                  data-testid="dashboard-cluster-reactivate-btn"
+                  as={Link}
+                  to="reactivate-balance"
+                  size="xl"
+                >
                   Reactivate Cluster
                 </Button>
               ) : (
                 <Button
+                  data-testid="dashboard-cluster-switch-to-eth-btn"
                   as={Link}
                   to={`/switch-wizard/${clusterHash}`}
                   state={{ from }}
@@ -123,6 +152,7 @@ export const Cluster: FC = () => {
                 <div className="flex gap-6 [&>*]:flex-1">
                   <SwitchToEthMenuOptionTooltip asChild enabled={!isMigrated}>
                     <Button
+                      data-testid="dashboard-cluster-deposit-btn"
                       as={Link}
                       to="deposit"
                       size="xl"
@@ -131,12 +161,19 @@ export const Cluster: FC = () => {
                       Deposit
                     </Button>
                   </SwitchToEthMenuOptionTooltip>
-                  <Button as={Link} to="withdraw" size="xl" variant="secondary">
+                  <Button
+                    data-testid="dashboard-cluster-withdraw-btn"
+                    as={Link}
+                    to="withdraw"
+                    size="xl"
+                    variant="secondary"
+                  >
                     Withdraw
                   </Button>
                 </div>
                 {!isMigrated && (
                   <Button
+                    data-testid="dashboard-cluster-switch-to-eth-btn"
                     as={Link}
                     to={`/switch-wizard/${clusterHash}`}
                     state={{ from }}
@@ -149,12 +186,24 @@ export const Cluster: FC = () => {
               </div>
             )}
           </Card>
-          <Card className="flex-[2] h-full">
+          <Card
+            data-testid="dashboard-cluster-validators-card"
+            className="flex-[2] h-full"
+          >
             <div className="flex w-full gap-2 justify-between">
-              <Text variant="headline4" className="text-gray-500">
+              <Text
+                data-testid="dashboard-cluster-validators-label"
+                variant="headline4"
+                className="text-gray-500"
+              >
                 Validators
               </Text>
-              <Badge size="sm" variant="primary" className="h-fit">
+              <Badge
+                data-testid="dashboard-cluster-validators-count"
+                size="sm"
+                variant="primary"
+                className="h-fit"
+              >
                 {cluster.data?.validatorCount}
               </Badge>
               <Spacer />
@@ -164,6 +213,7 @@ export const Cluster: FC = () => {
               />
               <Tooltip content={getTooltipContent()}>
                 <Button
+                  data-testid="dashboard-cluster-add-validator-btn"
                   disabled={
                     operatorsUsability.isError ||
                     operatorsUsability.data?.hasExceededValidatorsLimit ||

--- a/src/app/routes/dashboard/clusters/cluster/deposit-cluster-balance.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/deposit-cluster-balance.tsx
@@ -66,11 +66,19 @@ export const DepositClusterBalance: FC = () => {
   });
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-cluster-deposit-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="dashboard-cluster-deposit-back-btn" />
       <Form {...form}>
         <Card as="form" className="w-full" onSubmit={submit}>
-          <Text variant="headline4" className="text-gray-500">
+          <Text
+            data-testid="dashboard-cluster-deposit-title"
+            variant="headline4"
+            className="text-gray-500"
+          >
             Deposit
           </Text>
           <FormField
@@ -110,6 +118,7 @@ export const DepositClusterBalance: FC = () => {
                       <div className="flex flex-col pl-6 pr-5 py-4 gap-3 rounded-xl border border-gray-300 bg-gray-200">
                         <div className="flex h-14 items-center gap-5">
                           <input
+                            data-testid="dashboard-cluster-deposit-amount-input"
                             placeholder="0"
                             className="w-full h-full border outline-none flex-1 text-[28px] font-medium border-none bg-transparent"
                             {...props}
@@ -120,6 +129,7 @@ export const DepositClusterBalance: FC = () => {
                         <Divider />
                         <div className="flex justify-end">
                           <Text
+                            data-testid="dashboard-cluster-deposit-wallet-balance"
                             variant="body-2-medium"
                             className="text-gray-500"
                           >
@@ -144,6 +154,7 @@ export const DepositClusterBalance: FC = () => {
           )}
 
           <Button
+            data-testid="dashboard-cluster-deposit-submit-btn"
             type="submit"
             size="xl"
             disabled={!isChanged}

--- a/src/app/routes/dashboard/clusters/cluster/exit-validators-confirmation.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/exit-validators-confirmation.tsx
@@ -71,18 +71,25 @@ export const ExitValidatorsConfirmation: FC = () => {
 
   return (
     <Container
+      data-testid="dashboard-cluster-exit-confirmation-page"
       variant="vertical"
       size="xl"
       className="p-6 font-medium w-[1096px]"
     >
-      <NavigateBackBtn by="history" />
+      <NavigateBackBtn
+        data-testid="dashboard-cluster-exit-back-btn"
+        by="history"
+      />
       <div className="flex w-full gap-6">
         <Card className="flex-[1.7]">
           <CardHeader
             title="Exit validators"
             description="Exiting your validator signals to the network that you wish to permanently cease your validator's participation in the Beacon Chain and retrieve your 32 ETH stake principal."
           />
-          <Text className="text-gray-600">
+          <Text
+            data-testid="dashboard-cluster-exit-queue-info"
+            className="text-gray-600"
+          >
             Initiating an exit places your validator in the exit queue. The
             duration in the queue depends on the number of validators already
             waiting. During this period, your validator must remain active, so
@@ -90,13 +97,14 @@ export const ExitValidatorsConfirmation: FC = () => {
             registered with the SSV network until it has fully exited.
           </Text>
           <Alert variant="warning">
-            <AlertDescription>
+            <AlertDescription data-testid="dashboard-cluster-exit-warning">
               Exiting your validator from the Beacon Chain is permanent and
               cannot be reversed, preventing any future reactivation.
             </AlertDescription>
           </Alert>
           <label htmlFor="agree-1" className="flex gap-3">
             <Checkbox
+              data-testid="dashboard-cluster-exit-agree-1-checkbox"
               checked={agree1}
               id="agree-1"
               className="mt-1"
@@ -109,6 +117,7 @@ export const ExitValidatorsConfirmation: FC = () => {
           </label>
           <label htmlFor="agree-2" className="flex gap-3">
             <Checkbox
+              data-testid="dashboard-cluster-exit-agree-2-checkbox"
               checked={agree2}
               id="agree-2"
               className="mt-1"
@@ -122,6 +131,7 @@ export const ExitValidatorsConfirmation: FC = () => {
           </label>
           <label htmlFor="agree-3" className="flex gap-3">
             <Checkbox
+              data-testid="dashboard-cluster-exit-agree-3-checkbox"
               checked={agree3}
               id="agree-3"
               className="mt-1"
@@ -134,6 +144,7 @@ export const ExitValidatorsConfirmation: FC = () => {
             </Text>
           </label>
           <Button
+            data-testid="dashboard-cluster-exit-submit-btn"
             size="xl"
             disabled={!agree1 || !agree2 || !agree3}
             onClick={exit}

--- a/src/app/routes/dashboard/clusters/cluster/exit-validators-success.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/exit-validators-success.tsx
@@ -13,6 +13,7 @@ export const ExitValidatorsSuccess: FC = () => {
   const { selectedPublicKeys } = useBulkActionContext();
   return (
     <Container
+      data-testid="dashboard-cluster-exit-success-page"
       variant="horizontal"
       size="xl"
       className="p-6 font-medium w-[1096px]"
@@ -23,7 +24,9 @@ export const ExitValidatorsSuccess: FC = () => {
           description="Your request to exit the validator has been successfully broadcasted to the network."
         />
         <Divider />
-        <Text variant="headline4">Next Steps</Text>
+        <Text data-testid="dashboard-cluster-exit-success-next-steps-heading" variant="headline4">
+          Next Steps
+        </Text>
         <Text variant="body-2-medium">
           1. <Span variant="body-2-bold">Monitor Validator</Span>: Keep track of
           your validator until it fully exits.
@@ -35,7 +38,12 @@ export const ExitValidatorsSuccess: FC = () => {
           Keep in mind that you will continue to incur operational fees until
           it's removed, regardless of the validator's state on the Beacon Chain.
         </Text>
-        <Button as={Link} to="../.." size="xl">
+        <Button
+          data-testid="dashboard-cluster-exit-success-go-to-cluster-btn"
+          as={Link}
+          to="../.."
+          size="xl"
+        >
           Go to Cluster Page
         </Button>
       </Card>

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-header.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-header.tsx
@@ -41,10 +41,12 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
 
   return (
     <Card
+      data-testid="dashboard-migrated-cluster-header"
       className={cn("flex flex-row items-center gap-3 p-6 w-full", className)}
       {...props}
     >
       <Link
+        data-testid="dashboard-migrated-cluster-header-back-link"
         to="/clusters"
         className="flex items-center justify-center rounded-[6px] bg-gray-100 p-1.5"
       >
@@ -53,11 +55,16 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
 
       <div className="flex flex-1 items-center gap-5 min-w-0">
         <div className="flex items-center gap-2 min-w-0 overflow-hidden">
-          <Text variant="headline4" className="truncate">
+          <Text
+            data-testid="dashboard-migrated-cluster-header-name"
+            variant="headline4"
+            className="truncate"
+          >
             {clusterName || "Cluster"}
           </Text>
           {isOwner && (
             <button
+              data-testid="dashboard-migrated-cluster-header-edit-name-btn"
               onClick={() => setIsDialogOpen(true)}
               className="shrink-0 text-gray-400 hover:text-gray-600 transition-colors"
             >
@@ -72,16 +79,24 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
               ID:
             </Text>
             <Text
+              data-testid="dashboard-migrated-cluster-header-id"
               variant="body-3-medium"
               className="font-robotoMono text-gray-700"
             >
               {shortenClusterId(clusterId)}
             </Text>
-            <CopyBtn text={clusterId} />
+            <CopyBtn
+              data-testid="dashboard-migrated-cluster-header-id-copy-btn"
+              text={clusterId}
+            />
           </div>
 
           {isLiquidatedCluster && (
-            <Badge variant="error" size="xs">
+            <Badge
+              data-testid="dashboard-migrated-cluster-header-liquidated-badge"
+              variant="error"
+              size="xs"
+            >
               Liquidated
             </Badge>
           )}

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-name-dialog.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-name-dialog.tsx
@@ -109,13 +109,24 @@ export const ClusterNameDialog = ({
 
   return (
     <Dialog isOpen={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="w-[648px] max-w-[648px] gap-6 p-8">
-        <DialogClose className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 transition-colors">
+      <DialogContent
+        data-testid="cluster-name-dialog"
+        className="w-[648px] max-w-[648px] gap-6 p-8"
+      >
+        <DialogClose
+          data-testid="cluster-name-dialog-close-btn"
+          className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 transition-colors"
+        >
           <FaXmark className="size-4" />
         </DialogClose>
         <DialogHeader className="gap-3">
-          <DialogTitle>Cluster name</DialogTitle>
-          <p className="text-sm text-gray-700">
+          <DialogTitle data-testid="cluster-name-dialog-title">
+            Cluster name
+          </DialogTitle>
+          <p
+            data-testid="cluster-name-dialog-description"
+            className="text-sm text-gray-700"
+          >
             Set a display name for this cluster
           </p>
         </DialogHeader>
@@ -129,6 +140,7 @@ export const ClusterNameDialog = ({
                   <FormControl>
                     <div className="relative">
                       <Input
+                        data-testid="cluster-name-dialog-name-input"
                         placeholder="Cluster"
                         {...field}
                         onChange={(e) => {
@@ -146,6 +158,7 @@ export const ClusterNameDialog = ({
                       {field.value && (
                         <button
                           type="button"
+                          data-testid="cluster-name-dialog-clear-btn"
                           onClick={() => form.setValue("name", "", { shouldValidate: true, shouldDirty: true })}
                           className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 hover:text-gray-600 transition-colors"
                         >
@@ -156,9 +169,16 @@ export const ClusterNameDialog = ({
                   </FormControl>
                   {form.formState.dirtyFields.name &&
                     field.value.length > 0 &&
-                    !apiError && <FormMessage />}
+                    !apiError && (
+                      <FormMessage data-testid="cluster-name-dialog-name-error" />
+                    )}
                   {apiError && (
-                    <p className="text-sm text-error-500">{apiError}</p>
+                    <p
+                      data-testid="cluster-name-dialog-api-error"
+                      className="text-sm text-error-500"
+                    >
+                      {apiError}
+                    </p>
                   )}
                 </FormItem>
               )}
@@ -168,6 +188,7 @@ export const ClusterNameDialog = ({
               const isRemove = !!currentName && value === "";
               return (
                 <Button
+                  data-testid="cluster-name-dialog-submit-btn"
                   type="submit"
                   size="xl"
                   variant={isRemove ? "secondary" : "default"}

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-operators-table.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-operators-table.tsx
@@ -34,34 +34,38 @@ export const ClusterOperatorsTable: ClusterOperatorsTableFC = ({
 }) => {
   return (
     <Table
+      data-testid="dashboard-cluster-operators-table"
       gridTemplateColumns={GRID_COLUMNS}
       className={cn(className)}
       {...props}
     >
       <TableHeader>
-        <TableCell>
+        <TableCell data-testid="dashboard-cluster-operators-table-header-name">
           <Text variant="caption-medium" className="text-gray-500">
             Name
           </Text>
         </TableCell>
-        <TableCell>
+        <TableCell data-testid="dashboard-cluster-operators-table-header-status">
           <Text variant="caption-medium" className="text-gray-500">
             Status
           </Text>
         </TableCell>
-        <TableCell>
+        <TableCell data-testid="dashboard-cluster-operators-table-header-performance">
           <Text variant="caption-medium" className="text-gray-500">
             30D
           </Text>
         </TableCell>
-        <TableCell className="justify-end">
+        <TableCell
+          data-testid="dashboard-cluster-operators-table-header-fee"
+          className="justify-end"
+        >
           <Text variant="caption-medium" className="text-gray-500">
             1Y Fee
           </Text>
         </TableCell>
       </TableHeader>
-      {operators.map((operator) => (
-        <OperatorRow key={operator.id} operator={operator} />
+      {operators.map((operator, index) => (
+        <OperatorRow key={operator.id} operator={operator} rowIndex={index} />
       ))}
     </Table>
   );
@@ -69,7 +73,10 @@ export const ClusterOperatorsTable: ClusterOperatorsTableFC = ({
 
 ClusterOperatorsTable.displayName = "ClusterOperatorsTable";
 
-const OperatorRow: FC<{ operator: Operator }> = ({ operator }) => {
+const OperatorRow: FC<{ operator: Operator; rowIndex: number }> = ({
+  operator,
+  rowIndex,
+}) => {
   const isInactive = operator.is_active < 1;
   const yearlyFee = getYearlyFee(BigInt(operator.eth_fee), {
     format: true,
@@ -77,7 +84,12 @@ const OperatorRow: FC<{ operator: Operator }> = ({ operator }) => {
   });
 
   return (
-    <TableRow className="items-center h-[60px]">
+    <TableRow
+      data-testid="dashboard-cluster-operators-table-row"
+      data-testid-index={rowIndex}
+      data-testid-entity={operator.id}
+      className="items-center h-[60px]"
+    >
       <TableCell>
         <div className="flex items-center gap-3 min-w-0">
           <OperatorAvatar
@@ -88,6 +100,7 @@ const OperatorRow: FC<{ operator: Operator }> = ({ operator }) => {
           <div className="flex flex-col gap-0.5 min-w-0">
             <div className="flex items-center gap-1.5 h-3">
               <Text
+                data-testid="dashboard-cluster-operators-table-row-name"
                 variant="body-3-medium"
                 className="truncate"
                 title={operator.name}
@@ -95,28 +108,48 @@ const OperatorRow: FC<{ operator: Operator }> = ({ operator }) => {
                 {operator.name}
               </Text>
               {operator.type === "verified_operator" && (
-                <VerifiedSVG className="size-3.5 shrink-0" />
+                <VerifiedSVG
+                  data-testid="dashboard-cluster-operators-table-row-verified-icon"
+                  className="size-3.5 shrink-0"
+                />
               )}
-              <SsvExplorerBtn operatorId={operator.id} />
+              <SsvExplorerBtn
+                data-testid="dashboard-cluster-operators-table-row-explorer-btn"
+                operatorId={operator.id}
+              />
             </div>
             <div className="flex items-center gap-1">
-              <Text variant="caption-medium" className="text-gray-500">
+              <Text
+                data-testid="dashboard-cluster-operators-table-row-id"
+                variant="caption-medium"
+                className="text-gray-500"
+              >
                 ID: {operator.id}
               </Text>
-              <CopyBtn text={operator.id.toString()} />
+              <CopyBtn
+                data-testid="dashboard-cluster-operators-table-row-id-copy-btn"
+                text={operator.id.toString()}
+              />
             </div>
           </div>
         </div>
       </TableCell>
       <TableCell>
-        <OperatorStatusBadge size="xs" status={operator.status} />
+        <OperatorStatusBadge
+          data-testid="dashboard-cluster-operators-table-row-status"
+          size="xs"
+          status={operator.status}
+        />
       </TableCell>
       <TableCell
         className={cn({
           "text-error-500": isInactive,
         })}
       >
-        <Text variant="body-3-medium">
+        <Text
+          data-testid="dashboard-cluster-operators-table-row-performance"
+          variant="body-3-medium"
+        >
           {percentageFormatter.format(operator.performance["30d"])}
         </Text>
       </TableCell>
@@ -127,7 +160,12 @@ const OperatorRow: FC<{ operator: Operator }> = ({ operator }) => {
             src="/images/networks/dark.svg"
             className="size-5"
           />
-          <Text variant="body-3-medium">{yearlyFee}</Text>
+          <Text
+            data-testid="dashboard-cluster-operators-table-row-fee"
+            variant="body-3-medium"
+          >
+            {yearlyFee}
+          </Text>
         </div>
       </TableCell>
     </TableRow>

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-validators-list.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-validators-list.tsx
@@ -38,7 +38,10 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
   const isSsvCluster = !cluster.data?.migrated;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div
+      data-testid="dashboard-cluster-validators-list"
+      className="flex flex-col gap-4"
+    >
       <ValidatorsSearchAndFilters />
       <VirtualizedInfinityTable
         gridTemplateColumns="220px minmax(200px, auto) 120px"
@@ -59,24 +62,46 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
         ]}
         items={validators}
         renderRow={({ index, item }) => (
-          <TableRow key={index}>
+          <TableRow
+            data-testid="dashboard-cluster-validators-row"
+            data-testid-index={index}
+            data-testid-entity={item.public_key}
+            key={index}
+          >
             <TableCell className="flex gap-2 items-center">
-              <Text variant="body-2-medium">
+              <Text
+                data-testid="dashboard-cluster-validators-row-pubkey"
+                variant="body-2-medium"
+              >
                 {shortenAddress(add0x(item.public_key))}
               </Text>
-              <CopyBtn variant="subtle" text={item.public_key} />
+              <CopyBtn
+                data-testid="dashboard-cluster-validators-row-pubkey-copy-btn"
+                variant="subtle"
+                text={item.public_key}
+              />
             </TableCell>
             <TableCell>
-              <ValidatorStatusBadge size="sm" status={item.displayedStatus} />
+              <ValidatorStatusBadge
+                data-testid="dashboard-cluster-validators-row-status"
+                size="sm"
+                status={item.displayedStatus}
+              />
             </TableCell>
             <TableCell className="flex gap-0.5 justify-end">
-              <SsvExplorerBtn validatorId={item.public_key} />
-              <BeaconchainBtn validatorId={item.public_key} />
+              <SsvExplorerBtn
+                data-testid="dashboard-cluster-validators-row-explorer-btn"
+                validatorId={item.public_key}
+              />
+              <BeaconchainBtn
+                data-testid="dashboard-cluster-validators-row-beaconchain-btn"
+                validatorId={item.public_key}
+              />
 
               {cluster.data && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <IconButton>
+                    <IconButton data-testid="dashboard-cluster-validators-row-actions-trigger">
                       <HiOutlineCog />
                     </IconButton>
                   </DropdownMenuTrigger>
@@ -86,7 +111,10 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
                       target="_blank"
                       className={cn({ "pointer-events-none": isSsvCluster })}
                     >
-                      <DropdownMenuItem disabled={isSsvCluster}>
+                      <DropdownMenuItem
+                        data-testid="dashboard-cluster-validators-row-change-operators-item"
+                        disabled={isSsvCluster}
+                      >
                         <TbRefresh className="size-4" />
                         <span>Change Operators</span>
                         <Spacer />
@@ -94,6 +122,7 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
                       </DropdownMenuItem>
                     </a>
                     <DropdownMenuItem
+                      data-testid="dashboard-cluster-validators-row-remove-item"
                       onClick={() => {
                         useBulkActionContext.state.selectedPublicKeys = [
                           item.public_key,
@@ -115,6 +144,7 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
                       }
                     >
                       <DropdownMenuItem
+                        data-testid="dashboard-cluster-validators-row-exit-item"
                         disabled={cluster.data?.isLiquidated}
                         onClick={() => {
                           useBulkActionContext.state.selectedPublicKeys = [

--- a/src/app/routes/dashboard/clusters/cluster/migrated/migrated-cluster.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/migrated-cluster.tsx
@@ -77,7 +77,12 @@ export const MigratedCluster: FC = () => {
 
   return (
     <>
-      <Container variant="vertical" size="xl" className="min-h-full py-6">
+      <Container
+        data-testid="dashboard-migrated-cluster-page"
+        variant="vertical"
+        size="xl"
+        className="min-h-full py-6"
+      >
         <ClusterHeader />
         <div className="flex flex-1 items-start gap-6 w-full">
           <div className="flex flex-[1] flex-col gap-6 min-w-0">
@@ -101,6 +106,7 @@ export const MigratedCluster: FC = () => {
             <div className="flex w-full gap-2 justify-between">
               <div className="flex gap-3 items-center">
                 <Tab
+                  data-testid="dashboard-migrated-cluster-tab-validators"
                   as={Link}
                   to={`/clusters/${clusterHash}`}
                   count={cluster.data?.validatorCount}
@@ -109,6 +115,7 @@ export const MigratedCluster: FC = () => {
                   Validators
                 </Tab>
                 <Tab
+                  data-testid="dashboard-migrated-cluster-tab-operators"
                   as={Link}
                   to={`/clusters/${clusterHash}/operators`}
                   count={cluster.data?.operators.length}
@@ -124,6 +131,7 @@ export const MigratedCluster: FC = () => {
               />
               <Tooltip content={getTooltipContent()}>
                 <Button
+                  data-testid="dashboard-migrated-cluster-add-validator-btn"
                   disabled={
                     operatorsUsability.isError ||
                     operatorsUsability.data?.hasExceededValidatorsLimit ||

--- a/src/app/routes/dashboard/clusters/cluster/migrated/operational-runway-card.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/operational-runway-card.tsx
@@ -69,20 +69,28 @@ export const OperationalRunwayCard: FC<OperationalRunwayCardProps> = ({
     (fundingCost.data?.subtotal.networkCost ?? 0n);
 
   return (
-    <Card className="w-full flex-1 p-6 gap-6">
+    <Card
+      data-testid="dashboard-operational-runway-card"
+      className="w-full flex-1 p-6 gap-6"
+    >
       <div className="flex items-center justify-between">
         <Tooltip
           className="max-w-[336px]"
           content="Estimated amount of days the cluster balance is sufficient to run all its validators"
         >
           <div className="flex items-center gap-1">
-            <Text variant="headline4" className="text-gray-500">
+            <Text
+              data-testid="dashboard-operational-runway-label"
+              variant="headline4"
+              className="text-gray-500"
+            >
               Est. Operational Runway
             </Text>
             <FaCircleInfo className="size-4 text-gray-500" />
           </div>
         </Tooltip>
         <Text
+          data-testid="dashboard-operational-runway-days"
           variant="headline4"
           className={cn(isProjected ? "text-primary-500" : "text-gray-700")}
         >
@@ -210,15 +218,31 @@ export const OperationalRunwayCard: FC<OperationalRunwayCardProps> = ({
         runway={runway?.runway ?? 0n}
       />
       {isLiquidated ? (
-        <Button as={Link} to="reactivate-balance" size="xl">
+        <Button
+          data-testid="dashboard-operational-runway-reactivate-btn"
+          as={Link}
+          to="reactivate-balance"
+          size="xl"
+        >
           Reactivate Cluster
         </Button>
       ) : (
         <div className="flex gap-3 [&>*]:flex-1 pt-2">
-          <Button as={Link} to="deposit" size="xl">
+          <Button
+            data-testid="dashboard-operational-runway-deposit-btn"
+            as={Link}
+            to="deposit"
+            size="xl"
+          >
             Deposit
           </Button>
-          <Button as={Link} to="withdraw" size="xl" variant="secondary">
+          <Button
+            data-testid="dashboard-operational-runway-withdraw-btn"
+            as={Link}
+            to="withdraw"
+            size="xl"
+            variant="secondary"
+          >
             Withdraw
           </Button>
         </div>

--- a/src/app/routes/dashboard/clusters/cluster/remove-validators-confirmation.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/remove-validators-confirmation.tsx
@@ -93,11 +93,15 @@ export const RemoveValidatorsConfirmation: FC = () => {
 
   return (
     <Container
+      data-testid="dashboard-cluster-remove-confirmation-page"
       variant="vertical"
       size="xl"
       className="p-6 font-medium w-[1096px]"
     >
-      <NavigateBackBtn by="history" />
+      <NavigateBackBtn
+        data-testid="dashboard-cluster-remove-back-btn"
+        by="history"
+      />
       <div className="flex w-full gap-6">
         <Card className="flex-[1.7]">
           <CardHeader
@@ -109,13 +113,14 @@ export const RemoveValidatorsConfirmation: FC = () => {
             network and does not exit your validator from the Beacon Chain.
           </Text>
           <Alert variant="warning">
-            <AlertDescription>
+            <AlertDescription data-testid="dashboard-cluster-remove-warning">
               To avoid slashing, it is advised to wait at least 2 epochs prior
               to running the validator on an alternative service.
             </AlertDescription>
           </Alert>
           <label htmlFor="agree-1" className="flex gap-3">
             <Checkbox
+              data-testid="dashboard-cluster-remove-agreement-checkbox"
               checked={agree1}
               id="agree-1"
               className="mt-1"
@@ -127,6 +132,7 @@ export const RemoveValidatorsConfirmation: FC = () => {
             </Text>
           </label>
           <Button
+            data-testid="dashboard-cluster-remove-submit-btn"
             size="xl"
             disabled={!agree1}
             onClick={remove}

--- a/src/app/routes/dashboard/clusters/cluster/withdraw-cluster-balance.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/withdraw-cluster-balance.tsx
@@ -115,19 +115,30 @@ export const WithdrawClusterBalance: FC = () => {
   });
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-cluster-withdraw-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="dashboard-cluster-withdraw-back-btn" />
       <Card className="w-full gap-2">
         <Text variant="headline4" className="text-gray-500">
           Available Balance
         </Text>
-        <Text variant="headline1">
+        <Text
+          data-testid="dashboard-cluster-withdraw-available-balance"
+          variant="headline1"
+        >
           {formatSSV(clusterBalance)} {symbol}
         </Text>
       </Card>
       <Form {...form}>
         <Card as="form" className="w-full" onSubmit={submit}>
-          <Text variant="headline4" className="text-gray-500">
+          <Text
+            data-testid="dashboard-cluster-withdraw-title"
+            variant="headline4"
+            className="text-gray-500"
+          >
             Withdraw
           </Text>
           <FormField
@@ -146,6 +157,7 @@ export const WithdrawClusterBalance: FC = () => {
                       <div className="flex flex-col pl-6 pr-5 py-4 gap-3 rounded-xl border border-gray-300 bg-gray-200">
                         <div className="flex h-14 items-center gap-5">
                           <input
+                            data-testid="dashboard-cluster-withdraw-amount-input"
                             placeholder="0"
                             className="w-full h-full border outline-none flex-1 text-[28px] font-medium border-none bg-transparent"
                             {...props}
@@ -154,6 +166,7 @@ export const WithdrawClusterBalance: FC = () => {
                           />
                           {!isSsvCluster && (
                             <Button
+                              data-testid="dashboard-cluster-withdraw-max-btn"
                               size="lg"
                               variant="secondary"
                               className="font-semibold px-4"
@@ -192,13 +205,17 @@ export const WithdrawClusterBalance: FC = () => {
 
           {isSsvCluster && (
             <Alert variant="warning">
-              <AlertDescription className="flex flex-col gap-4">
+              <AlertDescription
+                data-testid="dashboard-cluster-withdraw-liquidation-warning"
+                className="flex flex-col gap-4"
+              >
                 <p>
                   Withdrawing from an SSV cluster is full-withdrawal only
                   (partial withdrawals aren't allowed). Proceeding will withdraw
                   the entire cluster balance and liquidate your cluster, which
                   will result in inactivation (
                   <Button
+                    data-testid="dashboard-cluster-withdraw-penalties-link"
                     variant="link"
                     as="a"
                     target="_blank"
@@ -210,6 +227,7 @@ export const WithdrawClusterBalance: FC = () => {
                   the network.
                 </p>
                 <Button
+                  data-testid="dashboard-cluster-withdraw-liquidation-docs-link"
                   variant="link"
                   as="a"
                   target="_blank"
@@ -224,6 +242,7 @@ export const WithdrawClusterBalance: FC = () => {
           {showRiskCheckbox && (
             <label className="flex items-center gap-2" id="understand">
               <Checkbox
+                data-testid="dashboard-cluster-withdraw-agreement-checkbox"
                 checked={hasAgreed}
                 id="understand"
                 className="border border-gray-500"
@@ -237,6 +256,7 @@ export const WithdrawClusterBalance: FC = () => {
             </label>
           )}
           <Button
+            data-testid="dashboard-cluster-withdraw-submit-btn"
             type="submit"
             size="xl"
             disabled={!isChanged || disabled}

--- a/src/app/routes/dashboard/clusters/clusters.tsx
+++ b/src/app/routes/dashboard/clusters/clusters.tsx
@@ -22,11 +22,17 @@ export const Clusters: FC<ComponentPropsWithoutRef<"div">> = () => {
         <title>SSV My Clusters</title>
       </Helmet>
 
-      <Container variant="vertical" size="xl" className="py-6">
+      <Container
+        data-testid="dashboard-clusters-page"
+        variant="vertical"
+        size="xl"
+        className="py-6"
+      >
         <div className="flex justify-between w-full gap-3">
           <DashboardPicker />
           <Spacer />
           <Button
+            data-testid="dashboard-clusters-fee-address-btn"
             size="lg"
             variant="secondary"
             as={Link}
@@ -35,7 +41,13 @@ export const Clusters: FC<ComponentPropsWithoutRef<"div">> = () => {
           >
             Fee Address <FiEdit3 />
           </Button>
-          <Button size="lg" className="px-10" as={Link} to="/join/validator">
+          <Button
+            data-testid="dashboard-clusters-add-cluster-btn"
+            size="lg"
+            className="px-10"
+            as={Link}
+            to="/join/validator"
+          >
             Add Cluster
           </Button>
         </div>

--- a/src/app/routes/dashboard/clusters/fee-recipient-address.tsx
+++ b/src/app/routes/dashboard/clusters/fee-recipient-address.tsx
@@ -97,8 +97,15 @@ export const FeeRecipientAddress: FC<ComponentPropsWithoutRef<"div">> = () => {
   });
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="dashboard-fee-recipient-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="dashboard-fee-recipient-back-btn"
+        by="history"
+      />
       <Form {...form}>
         <Card as="form" onSubmit={submit}>
           <CardHeader
@@ -108,6 +115,7 @@ export const FeeRecipientAddress: FC<ComponentPropsWithoutRef<"div">> = () => {
                 Enter an Ethereum address that will receive all of your
                 validators block proposal rewards.{" "}
                 <Button
+                  data-testid="dashboard-fee-recipient-proposal-rewards-link"
                   as={Link}
                   variant="link"
                   to="https://docs.ssv.network/stakers/validators/validator-rewards/"
@@ -121,7 +129,7 @@ export const FeeRecipientAddress: FC<ComponentPropsWithoutRef<"div">> = () => {
           />
 
           <Alert variant="warning">
-            <AlertDescription>
+            <AlertDescription data-testid="dashboard-fee-recipient-warning">
               Standard rewards from performing other duties will remain to be
               credited to your validators balance on the Beacon Chain.
             </AlertDescription>
@@ -131,19 +139,23 @@ export const FeeRecipientAddress: FC<ComponentPropsWithoutRef<"div">> = () => {
             name="feeRecipientAddress"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Fee Recipient Address</FormLabel>
+                <FormLabel data-testid="dashboard-fee-recipient-address-label">
+                  Fee Recipient Address
+                </FormLabel>
                 <FormControl>
                   <Input
+                    data-testid="dashboard-fee-recipient-address-input"
                     isLoading={ssvAccount.isLoading}
                     disabled={ssvAccount.isLoading}
                     {...field}
                   />
                 </FormControl>
-                <FormMessage />
+                <FormMessage data-testid="dashboard-fee-recipient-address-error" />
               </FormItem>
             )}
           />
           <Button
+            data-testid="dashboard-fee-recipient-update-btn"
             type="submit"
             size="xl"
             isLoading={setFeeRecipient.isPending}

--- a/src/app/routes/dashboard/operators/no-your-operator.tsx
+++ b/src/app/routes/dashboard/operators/no-your-operator.tsx
@@ -5,13 +5,28 @@ import { Text } from "@/components/ui/text";
 
 export const NoYourOperator: FC<ComponentPropsWithoutRef<"div">> = () => {
   return (
-    <div className="flex flex-col gap-4 items-center justify-center h-full">
+    <div
+      data-testid="dashboard-no-your-operator-page"
+      className="flex flex-col gap-4 items-center justify-center h-full"
+    >
       <div className="flex flex-col gap-1">
-        <Text variant="body-1-bold">Not your operator</Text>
-        <Text variant="body-3-medium" className="text-gray-500">
+        <Text data-testid="dashboard-no-your-operator-title" variant="body-1-bold">
+          Not your operator
+        </Text>
+        <Text
+          data-testid="dashboard-no-your-operator-description"
+          variant="body-3-medium"
+          className="text-gray-500"
+        >
           You are not authorized to access this operator.
         </Text>
-        <Button className="mt-4" as={Link} to="/operators" size="lg">
+        <Button
+          data-testid="dashboard-no-your-operator-back-btn"
+          className="mt-4"
+          as={Link}
+          to="/operators"
+          size="lg"
+        >
           Back to Operators Dashboard
         </Button>
       </div>

--- a/src/app/routes/dashboard/operators/operator-not-found.tsx
+++ b/src/app/routes/dashboard/operators/operator-not-found.tsx
@@ -5,13 +5,28 @@ import { Text } from "@/components/ui/text";
 
 export const OperatorNotFound: FC<ComponentPropsWithoutRef<"div">> = () => {
   return (
-    <div className="flex flex-col gap-4 items-center justify-center h-full">
+    <div
+      data-testid="dashboard-operator-not-found-page"
+      className="flex flex-col gap-4 items-center justify-center h-full"
+    >
       <div className="flex flex-col gap-1">
-        <Text variant="body-1-bold">Operator Not Found</Text>
-        <Text variant="body-3-medium" className="text-gray-500">
+        <Text data-testid="dashboard-operator-not-found-title" variant="body-1-bold">
+          Operator Not Found
+        </Text>
+        <Text
+          data-testid="dashboard-operator-not-found-description"
+          variant="body-3-medium"
+          className="text-gray-500"
+        >
           The operator you are looking for does not exist.
         </Text>
-        <Button className="mt-4" as={Link} to="/operators" size="lg">
+        <Button
+          data-testid="dashboard-operator-not-found-back-btn"
+          className="mt-4"
+          as={Link}
+          to="/operators"
+          size="lg"
+        >
           Back to Operators Dashboard
         </Button>
       </div>

--- a/src/app/routes/dashboard/operators/operator-settings/authorized-addresses.tsx
+++ b/src/app/routes/dashboard/operators/operator-settings/authorized-addresses.tsx
@@ -76,18 +76,31 @@ export const AuthorizedAddresses = () => {
         onCancel={unsavedChangesBlocker.reset}
       />
       <PastingLimitExceededModal />
-      <Container variant="vertical" size="lg" className="max-h-full py-10">
+      <Container
+        data-testid="dashboard-authorized-addresses-page"
+        variant="vertical"
+        size="lg"
+        className="max-h-full py-10"
+      >
         <Form {...addManager.form}>
-          <NavigateBackBtn />
+          <NavigateBackBtn data-testid="dashboard-authorized-addresses-back-btn" />
           <Card as="form" onSubmit={submit} className="w-full h overflow-auto">
             <div className="flex flex-col gap-2">
               <div className="flex justify-between items-center">
-                <h2 className="text-xl font-bold">Authorized Addresses</h2>
+                <h2
+                  data-testid="dashboard-authorized-addresses-title"
+                  className="text-xl font-bold"
+                >
+                  Authorized Addresses
+                </h2>
                 <Tooltip
                   asChild
                   content="The maximum number of addresses for whitelist is 500"
                 >
-                  <Badge variant="primary">
+                  <Badge
+                    data-testid="dashboard-authorized-addresses-count-badge"
+                    variant="primary"
+                  >
                     {totalAddresses} of 500 Addresses
                   </Badge>
                 </Tooltip>
@@ -134,10 +147,12 @@ export const AuthorizedAddresses = () => {
                     <FormItem>
                       <FormControl>
                         <Input
+                          data-testid={`dashboard-authorized-addresses-input-${index}`}
                           {...field}
                           onPaste={handlePaste(index)}
                           rightSlot={
                             <Button
+                              data-testid={`dashboard-authorized-addresses-remove-${index}-btn`}
                               variant="ghost"
                               size="icon"
                               onClick={() =>
@@ -168,6 +183,7 @@ export const AuthorizedAddresses = () => {
                   }
                 >
                   <button
+                    data-testid="dashboard-authorized-addresses-add-btn"
                     disabled={isAddBtnDisabled}
                     type="button"
                     className="sticky bottom-0 outline outline-[8px] outline-gray-50 bg-gray-50 h-12 w-full text-center border border-gray-400 border-dashed rounded-lg text-gray-500 font-medium"
@@ -182,6 +198,7 @@ export const AuthorizedAddresses = () => {
             {mode !== "view" && (
               <div className="flex gap-3 w-full">
                 <Button
+                  data-testid="dashboard-authorized-addresses-cancel-btn"
                   type="button"
                   className="flex-1"
                   size="xl"
@@ -192,6 +209,7 @@ export const AuthorizedAddresses = () => {
                   Cancel
                 </Button>
                 <Button
+                  data-testid="dashboard-authorized-addresses-submit-btn"
                   className="flex-1"
                   size="xl"
                   type="submit"

--- a/src/app/routes/dashboard/operators/operator-settings/external-contract.tsx
+++ b/src/app/routes/dashboard/operators/operator-settings/external-contract.tsx
@@ -148,9 +148,14 @@ export const ExternalContract: FC = () => {
   });
 
   return (
-    <Container variant="vertical" size="lg" className="py-6">
+    <Container
+      data-testid="dashboard-external-contract-page"
+      variant="vertical"
+      size="lg"
+      className="py-6"
+    >
       <Form {...form}>
-        <NavigateBackBtn />
+        <NavigateBackBtn data-testid="dashboard-external-contract-back-btn" />
         <Card>
           <form className="flex flex-col gap-8 w-full" onSubmit={submit}>
             <div className="flex flex-col gap-2">
@@ -198,11 +203,13 @@ export const ExternalContract: FC = () => {
                 <FormItem>
                   <FormControl>
                     <Input
+                      data-testid="dashboard-external-contract-input"
                       {...field}
                       placeholder="0xCONT...RACT"
                       rightSlot={
                         field.value && (
                           <Button
+                            data-testid="dashboard-external-contract-clear-btn"
                             variant="ghost"
                             size="icon"
                             onClick={() => field.onChange("")}
@@ -227,6 +234,7 @@ export const ExternalContract: FC = () => {
             {isChanged && (
               <div className="flex gap-3">
                 <Button
+                  data-testid="dashboard-external-contract-cancel-btn"
                   type="button"
                   disabled={isPending}
                   size="xl"
@@ -237,6 +245,7 @@ export const ExternalContract: FC = () => {
                   Cancel
                 </Button>
                 <Button
+                  data-testid="dashboard-external-contract-save-btn"
                   type="submit"
                   disabled={hasErrors}
                   isLoading={isPending}

--- a/src/app/routes/dashboard/operators/operator-settings/operator-metadata.tsx
+++ b/src/app/routes/dashboard/operators/operator-settings/operator-metadata.tsx
@@ -117,8 +117,13 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
       });
   };
   return (
-    <Container variant="vertical" className={cn(className, "py-6")} {...props}>
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-operator-metadata-page"
+      variant="vertical"
+      className={cn(className, "py-6")}
+      {...props}
+    >
+      <NavigateBackBtn data-testid="dashboard-operator-metadata-back-btn" />
       <Form {...form}>
         <Card as="form" className="w-full" onSubmit={form.handleSubmit(submit)}>
           <FormField
@@ -128,7 +133,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
               <FormItem>
                 <FormLabel>Operator name</FormLabel>
                 <FormControl>
-                  <Input placeholder="" {...field} />
+                  <Input
+                    data-testid="dashboard-operator-metadata-name-input"
+                    placeholder=""
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -167,7 +176,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
               <FormItem>
                 <FormLabel>Description</FormLabel>
                 <FormControl>
-                  <Textarea placeholder="Description" {...field} />
+                  <Textarea
+                    data-testid="dashboard-operator-metadata-description-input"
+                    placeholder="Description"
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -180,7 +193,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
               <FormItem>
                 <FormLabel>Cloud Provider</FormLabel>
                 <FormControl>
-                  <Input placeholder="AWS, Azure, Google Cloud..." {...field} />
+                  <Input
+                    data-testid="dashboard-operator-metadata-setup-provider-input"
+                    placeholder="AWS, Azure, Google Cloud..."
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -306,7 +323,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
               <FormItem>
                 <FormLabel>Website Link</FormLabel>
                 <FormControl>
-                  <Input placeholder="Enter your Website Link" {...field} />
+                  <Input
+                    data-testid="dashboard-operator-metadata-website-input"
+                    placeholder="Enter your Website Link"
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -320,7 +341,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
                 <FormItem>
                   <FormLabel>Twitter</FormLabel>
                   <FormControl>
-                    <Input placeholder="Enter your Twitter Link" {...field} />
+                    <Input
+                      data-testid="dashboard-operator-metadata-twitter-input"
+                      placeholder="Enter your Twitter Link"
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -335,7 +360,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
               <FormItem>
                 <FormLabel>Linkedin</FormLabel>
                 <FormControl>
-                  <Input placeholder="Enter your Linkedin Link" {...field} />
+                  <Input
+                    data-testid="dashboard-operator-metadata-linkedin-input"
+                    placeholder="Enter your Linkedin Link"
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -355,13 +384,18 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
                   </FormLabel>
                 </Tooltip>
                 <FormControl>
-                  <Input placeholder="Enter your Website Link" {...field} />
+                  <Input
+                    data-testid="dashboard-operator-metadata-dkg-address-input"
+                    placeholder="Enter your Website Link"
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
             )}
           />
           <Button
+            data-testid="dashboard-operator-metadata-submit-btn"
             size="xl"
             isLoading={sign.isPending}
             type="submit"

--- a/src/app/routes/dashboard/operators/operator-settings/operator-settings.tsx
+++ b/src/app/routes/dashboard/operators/operator-settings/operator-settings.tsx
@@ -20,9 +20,17 @@ export const OperatorSettings: FC<ComponentPropsWithoutRef<"div">> = () => {
   );
 
   return (
-    <Container variant="vertical" className="mt-6" size="lg">
-      <NavigateBackBtn>{operator?.name}</NavigateBackBtn>
+    <Container
+      data-testid="dashboard-operator-settings-page"
+      variant="vertical"
+      className="mt-6"
+      size="lg"
+    >
+      <NavigateBackBtn data-testid="dashboard-operator-settings-back-btn">
+        {operator?.name}
+      </NavigateBackBtn>
       <Card
+        data-testid="dashboard-operator-settings-card"
         variant="unstyled"
         className="not-last:border-b not-last:border-gray-100 overflow-hidden"
       >

--- a/src/app/routes/dashboard/operators/operator-settings/operator-status.tsx
+++ b/src/app/routes/dashboard/operators/operator-settings/operator-status.tsx
@@ -46,12 +46,22 @@ export const OperatorStatus: FC = () => {
   };
 
   return (
-    <Container variant="vertical" size="lg" className="py-6">
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-operator-status-page"
+      variant="vertical"
+      size="lg"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="dashboard-operator-status-back-btn" />
       <Card>
         <div className="flex flex-col gap-8 w-full">
           <div className="flex flex-col gap-4">
-            <h1 className="text-xl font-bold">Operator Status</h1>
+            <h1
+              data-testid="dashboard-operator-status-title"
+              className="text-xl font-bold"
+            >
+              Operator Status
+            </h1>
             <div className="flex flex-col gap-3 font-medium text-sm text-gray-700">
               <p>
                 Control validator access by switching between public and private
@@ -87,6 +97,7 @@ export const OperatorStatus: FC = () => {
             </Alert>
           )}
           <Button
+            data-testid="dashboard-operator-status-toggle-btn"
             disabled={isFeeZero && operator?.is_private}
             size="xl"
             className="w-full"

--- a/src/app/routes/dashboard/operators/operator.tsx
+++ b/src/app/routes/dashboard/operators/operator.tsx
@@ -36,11 +36,16 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
       <Helmet>
         <title>SSV {operator.data?.name ?? ""}</title>
       </Helmet>
-      <div className="flex flex-col h-full gap-6 pb-6">
+      <div
+        data-testid="dashboard-operator-page"
+        className="flex flex-col h-full gap-6 pb-6"
+      >
         <div className="bg-gray-100 w-full h-[208px] pb-6">
           <Container size="xl" variant="vertical" className="pt-6">
             <div className="flex w-full items-center justify-between">
-              <NavigateBackBtn>Operator Details</NavigateBackBtn>
+              <NavigateBackBtn data-testid="dashboard-operator-back-btn">
+                Operator Details
+              </NavigateBackBtn>
               <OperatorSettingsBtn />
             </div>
             <div className="flex items-start flex-1 gap-20">
@@ -65,7 +70,10 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
                 <Text variant="body-3-medium" className="text-gray-500">
                   Validators
                 </Text>
-                <Text variant="body-2-medium">
+                <Text
+                  data-testid="dashboard-operator-validators-count"
+                  variant="body-2-medium"
+                >
                   {operator.data.validators_count}
                 </Text>
               </div>
@@ -73,7 +81,10 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
                 <Text variant="body-3-medium" className="text-gray-500">
                   30D Performance
                 </Text>
-                <Text variant="body-2-medium">
+                <Text
+                  data-testid="dashboard-operator-performance"
+                  variant="body-2-medium"
+                >
                   {percentageFormatter.format(operator.data.performance["30d"])}
                 </Text>
               </div>
@@ -87,7 +98,10 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
                     src="/images/networks/dark.svg"
                     className="size-5"
                   />
-                  <Text variant="body-2-medium">
+                  <Text
+                    data-testid="dashboard-operator-effective-balance"
+                    variant="body-2-medium"
+                  >
                     {operator.data.effective_balance} ETH
                   </Text>
                 </div>
@@ -97,19 +111,34 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
         </div>
         <Container variant="horizontal" size="xl" {...props} className="h-full">
           <div className="flex items-stretch gap-6 flex-col flex-1">
-            <Card className="w-full">
-              <Text variant="headline4" className="text-gray-500">
+            <Card data-testid="dashboard-operator-balance-card" className="w-full">
+              <Text
+                data-testid="dashboard-operator-balance-label"
+                variant="headline4"
+                className="text-gray-500"
+              >
                 Balance
               </Text>
               <div className="flex flex-col gap-4">
-                <BalanceDisplay amount={balanceEth} token="ETH" />
-                {yearlyFeeSSV !== 0n && !operator.data.migrated && <BalanceDisplay amount={balanceSSV} token="SSV" />}
+                <BalanceDisplay
+                  data-testid="dashboard-operator-balance-eth"
+                  amount={balanceEth}
+                  token="ETH"
+                />
+                {yearlyFeeSSV !== 0n && !operator.data.migrated && (
+                  <BalanceDisplay
+                    data-testid="dashboard-operator-balance-ssv"
+                    amount={balanceSSV}
+                    token="SSV"
+                  />
+                )}
               </div>
               <Tooltip
                 asChild
                 content={!hasBalance ? "No balance to withdraw" : undefined}
               >
                 <Button
+                  data-testid="dashboard-operator-withdraw-btn"
                   as={Link}
                   to="withdraw"
                   variant="default"
@@ -120,17 +149,29 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
                 </Button>
               </Tooltip>
             </Card>
-            <Card className="w-full">
+            <Card data-testid="dashboard-operator-fee-card" className="w-full">
               <div className="flex w-full justify-between items-center">
-                <Text variant="headline4" className="text-gray-500">
+                <Text
+                  data-testid="dashboard-operator-fee-label"
+                  variant="headline4"
+                  className="text-gray-500"
+                >
                   Annual Fee
                 </Text>
                 <IncreaseOperatorFeeStatusBadge />
               </div>
               <div className="flex flex-col gap-4">
-                <BalanceDisplay amount={yearlyFeeEth} token="ETH" />
+                <BalanceDisplay
+                  data-testid="dashboard-operator-yearly-fee-eth"
+                  amount={yearlyFeeEth}
+                  token="ETH"
+                />
                 {yearlyFeeSSV > 0 && (
-                  <BalanceDisplay amount={yearlyFeeSSV} token="SSV" />
+                  <BalanceDisplay
+                    data-testid="dashboard-operator-yearly-fee-ssv"
+                    amount={yearlyFeeSSV}
+                    token="SSV"
+                  />
                 )}
               </div>
               <Tooltip
@@ -153,6 +194,7 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
                 }
               >
                 <Button
+                  data-testid="dashboard-operator-update-fee-btn"
                   as={Link}
                   disabled={feeEth.isLoading || feeEth.data === 0n}
                   to="fee/update"
@@ -164,8 +206,15 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
               </Tooltip>
             </Card>
           </div>
-          <Card className="flex-[2] h-full max-h-[800px] overflow-auto">
-            <Text variant="headline4" className="text-gray-500">
+          <Card
+            data-testid="dashboard-operator-validators-card"
+            className="flex-[2] h-full max-h-[800px] overflow-auto"
+          >
+            <Text
+              data-testid="dashboard-operator-validators-label"
+              variant="headline4"
+              className="text-gray-500"
+            >
               Validators
             </Text>
             <OperatorValidatorsList />

--- a/src/app/routes/dashboard/operators/operators.tsx
+++ b/src/app/routes/dashboard/operators/operators.tsx
@@ -17,10 +17,21 @@ export const Operators: FC<ComponentPropsWithoutRef<"div">> = () => {
         <title>SSV My Operators</title>
       </Helmet>
 
-      <Container variant="vertical" size="xl" className="py-6">
+      <Container
+        data-testid="dashboard-operators-page"
+        variant="vertical"
+        size="xl"
+        className="py-6"
+      >
         <div className="flex justify-between w-full gap-3">
           <DashboardPicker />
-          <Button size="lg" as={Link} className="px-10" to="/join/operator">
+          <Button
+            data-testid="dashboard-operators-add-operator-btn"
+            size="lg"
+            as={Link}
+            className="px-10"
+            to="/join/operator"
+          >
             Add Operator
           </Button>
         </div>

--- a/src/app/routes/dashboard/operators/remove-operator.tsx
+++ b/src/app/routes/dashboard/operators/remove-operator.tsx
@@ -35,8 +35,12 @@ export const RemoveOperator: FC = () => {
   const [accepted, setAccepted] = useState(false);
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-remove-operator-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="dashboard-remove-operator-back-btn" />
       <Card>
         <CardHeader
           title="Remove Operator"
@@ -51,13 +55,14 @@ export const RemoveOperator: FC = () => {
           discoverable by other validators.
         </Text>
         <Alert variant="error">
-          <AlertDescription>
+          <AlertDescription data-testid="dashboard-remove-operator-warning">
             Please note that this process is irreversible and you would not be
             able to reactive this operator in the future.
           </AlertDescription>
         </Alert>
         <div className="flex gap-2">
           <Checkbox
+            data-testid="dashboard-remove-operator-agreement-checkbox"
             id="accept"
             checked={accepted}
             onCheckedChange={(checked: boolean) => setAccepted(checked)}
@@ -68,6 +73,7 @@ export const RemoveOperator: FC = () => {
           </Text>
         </div>
         <Button
+          data-testid="dashboard-remove-operator-submit-btn"
           variant="destructive"
           size="xl"
           onClick={remove}

--- a/src/app/routes/dashboard/operators/update-fee/decrease-operator-fee.tsx
+++ b/src/app/routes/dashboard/operators/update-fee/decrease-operator-fee.tsx
@@ -50,8 +50,12 @@ export const DecreaseOperatorFee: FC = () => {
   };
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-decrease-fee-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="dashboard-decrease-fee-back-btn" />
       <Card>
         <CardHeader
           title="Update Fee"
@@ -94,6 +98,7 @@ export const DecreaseOperatorFee: FC = () => {
           </Alert>
         )}
         <Button
+          data-testid="dashboard-decrease-fee-submit-btn"
           size="xl"
           isLoading={reduceOperatorFee.isPending}
           onClick={submit}

--- a/src/app/routes/dashboard/operators/update-fee/increase-operator-fee.tsx
+++ b/src/app/routes/dashboard/operators/update-fee/increase-operator-fee.tsx
@@ -90,6 +90,7 @@ export const IncreaseOperatorFee: FC = () => {
     if (isCanceled || status.isExpired)
       return (
         <Button
+          data-testid="dashboard-increase-fee-declare-new-btn"
           size="xl"
           isActionBtn
           onClick={() => {
@@ -105,6 +106,7 @@ export const IncreaseOperatorFee: FC = () => {
     if (status.isDeclaration)
       return (
         <Button
+          data-testid="dashboard-increase-fee-declare-btn"
           size="xl"
           isActionBtn
           onClick={declare}
@@ -118,6 +120,7 @@ export const IncreaseOperatorFee: FC = () => {
       return (
         <div className="flex gap-3">
           <Button
+            data-testid="dashboard-increase-fee-cancel-btn"
             size="xl"
             className="flex-1"
             variant="secondary"
@@ -128,6 +131,7 @@ export const IncreaseOperatorFee: FC = () => {
             Cancel
           </Button>
           <Button
+            data-testid="dashboard-increase-fee-execute-btn"
             size="xl"
             className="flex-1"
             disabled={status.isWaiting}
@@ -141,7 +145,12 @@ export const IncreaseOperatorFee: FC = () => {
     }
 
     return (
-      <Button as={Link} to="../.." size="xl">
+      <Button
+        data-testid="dashboard-increase-fee-back-to-account-btn"
+        as={Link}
+        to="../.."
+        size="xl"
+      >
         Back to my account
       </Button>
     );
@@ -199,8 +208,16 @@ export const IncreaseOperatorFee: FC = () => {
   };
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="path" to="../.." />
+    <Container
+      data-testid="dashboard-increase-fee-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="dashboard-increase-fee-back-btn"
+        by="path"
+        to="../.."
+      />
       <Card className="w-full gap-8">
         <CardHeader title="Update Fee" />
 

--- a/src/app/routes/dashboard/operators/update-fee/operator-fee-updated.tsx
+++ b/src/app/routes/dashboard/operators/update-fee/operator-fee-updated.tsx
@@ -9,7 +9,11 @@ import { Link } from "react-router-dom";
 export const OperatorFeeUpdated: FC = () => {
   const state = useUpdateOperatorFeeContext();
   return (
-    <Container variant="vertical" className="py-6">
+    <Container
+      data-testid="dashboard-fee-updated-page"
+      variant="vertical"
+      className="py-6"
+    >
       <Card>
         <CardHeader
           title="Update Fee"
@@ -19,7 +23,12 @@ export const OperatorFeeUpdated: FC = () => {
           previousFee={state.previousYearlyFee}
           newFee={state.newYearlyFee}
         />
-        <Button as={Link} to="/operators" size="xl">
+        <Button
+          data-testid="dashboard-fee-updated-back-to-account-btn"
+          as={Link}
+          to="/operators"
+          size="xl"
+        >
           Back To My Account
         </Button>
       </Card>

--- a/src/app/routes/dashboard/operators/update-fee/update-operator-fee.tsx
+++ b/src/app/routes/dashboard/operators/update-fee/update-operator-fee.tsx
@@ -102,8 +102,17 @@ export const UpdateOperatorFee: FC<ComponentPropsWithoutRef<"div">> = ({
   const isChanged = isBigIntChanged(form.watch("yearlyFee"), operatorYearlyFee);
 
   return (
-    <Container variant="vertical" className={cn(className, "py-6")} {...props}>
-      <NavigateBackBtn by="path" to="../.." />
+    <Container
+      data-testid="dashboard-update-fee-page"
+      variant="vertical"
+      className={cn(className, "py-6")}
+      {...props}
+    >
+      <NavigateBackBtn
+        data-testid="dashboard-update-fee-back-btn"
+        by="path"
+        to="../.."
+      />
       <Form {...form}>
         <Card as="form" className="w-full" onSubmit={submit}>
           <CardHeader
@@ -124,12 +133,14 @@ export const UpdateOperatorFee: FC<ComponentPropsWithoutRef<"div">> = ({
                       <div className="flex flex-col pl-6 pr-5 py-4 gap-3 rounded-xl border border-gray-300 bg-gray-200">
                         <div className="flex h-14 items-center gap-5">
                           <input
+                            data-testid="dashboard-update-fee-yearly-fee-input"
                             placeholder="0"
                             className="w-full h-full border outline-none flex-1 text-[28px] font-medium border-none bg-transparent"
                             {...props}
                             ref={ref}
                           />
                           <Button
+                            data-testid="dashboard-update-fee-max-btn"
                             size="lg"
                             variant="secondary"
                             className="font-semibold px-4"
@@ -187,6 +198,7 @@ export const UpdateOperatorFee: FC<ComponentPropsWithoutRef<"div">> = ({
             </Alert>
           )}
           <Button
+            data-testid="dashboard-update-fee-next-btn"
             size="xl"
             type="submit"
             isLoading={isLoading}

--- a/src/app/routes/dashboard/operators/withdraw-operator-balance.tsx
+++ b/src/app/routes/dashboard/operators/withdraw-operator-balance.tsx
@@ -71,20 +71,38 @@ export const WithdrawOperatorBalance: FC<ComponentPropsWithoutRef<"div">> = ({
   };
 
   return (
-    <Container variant="vertical" className={cn(className, "py-6")} {...props}>
+    <Container
+      data-testid="dashboard-withdraw-operator-page"
+      variant="vertical"
+      className={cn(className, "py-6")}
+      {...props}
+    >
       <Helmet>
         <title>Withdraw {operator?.name ?? ""}</title>
       </Helmet>
-      <NavigateBackBtn>{operator?.name}</NavigateBackBtn>
+      <NavigateBackBtn data-testid="dashboard-withdraw-operator-back-btn">
+        {operator?.name}
+      </NavigateBackBtn>
       <Card className="w-full">
         <Text variant="headline4" className="text-gray-500">
           Available Balance
         </Text>
         <div className="flex flex-col gap-4">
-          <BalanceDisplay amount={balanceEth} token="ETH" />
-          {hasSSVBalance && <BalanceDisplay amount={balanceSSV} token="SSV" />}
+          <BalanceDisplay
+            data-testid="dashboard-withdraw-operator-balance-eth"
+            amount={balanceEth}
+            token="ETH"
+          />
+          {hasSSVBalance && (
+            <BalanceDisplay
+              data-testid="dashboard-withdraw-operator-balance-ssv"
+              amount={balanceSSV}
+              token="SSV"
+            />
+          )}
         </div>
         <Button
+          data-testid="dashboard-withdraw-operator-submit-btn"
           disabled={!hasBalance}
           isActionBtn
           isLoading={withdraw.isPending}

--- a/src/components/dashboard/dashboard-picker.tsx
+++ b/src/components/dashboard/dashboard-picker.tsx
@@ -19,9 +19,13 @@ export const DashboardPicker: DashboardPickerFC = ({ ...props }) => {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger>
+      <DropdownMenuTrigger data-testid="dashboard-picker-trigger">
         <div className="flex items-center gap-2">
-          <Text variant="headline3" {...props}>
+          <Text
+            data-testid="dashboard-picker-label"
+            variant="headline3"
+            {...props}
+          >
             {isOperators
               ? "Operators"
               : isValidators
@@ -33,10 +37,20 @@ export const DashboardPicker: DashboardPickerFC = ({ ...props }) => {
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         <DropdownMenuItem asChild defaultChecked={isValidators} className="">
-          <Link to="/clusters">Validator Clusters</Link>
+          <Link
+            data-testid="dashboard-picker-item-clusters"
+            to="/clusters"
+          >
+            Validator Clusters
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild defaultChecked={isOperators}>
-          <Link to="/operators">Operators</Link>
+          <Link
+            data-testid="dashboard-picker-item-operators"
+            to="/operators"
+          >
+            Operators
+          </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/operator/operators-table/operator-table-row.tsx
+++ b/src/components/operator/operators-table/operator-table-row.tsx
@@ -10,6 +10,7 @@ import { useOperatorEarningsAndFees } from "@/hooks/operator/use-operator-earnin
 
 export type OperatorTableRowProps = {
   operator: Operator;
+  rowIndex?: number;
 };
 
 type FCProps = FC<
@@ -19,6 +20,7 @@ type FCProps = FC<
 
 export const OperatorTableRow: FCProps = ({
   operator: _operator,
+  rowIndex,
   className,
   ...props
 }) => {
@@ -31,19 +33,25 @@ export const OperatorTableRow: FCProps = ({
   return (
     <TableRow
       key={operator.id}
+      data-testid="dashboard-operators-table-row"
+      data-testid-index={rowIndex}
+      data-testid-entity={operator.id}
       className={cn("cursor-pointer max-h-7", className)}
       {...props}
     >
-      <TableCell className="font-medium">
+      <TableCell
+        data-testid="dashboard-operators-table-row-name"
+        className="font-medium"
+      >
         <OperatorDetails operator={operator} />
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-status">
         <OperatorStatusBadge size="sm" status={operator.status} />
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-performance">
         {percentageFormatter.format(operator.performance["30d"])}
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-balance">
         <div className="flex items-center gap-2 w-max">
           <div className="flex items-center gap-1 text-gray-800 font-medium">
             <img
@@ -51,7 +59,9 @@ export const OperatorTableRow: FCProps = ({
               src="/images/networks/dark.svg"
               className="size-5"
             />{" "}
-            <span>{formatETH(balanceEth)}</span>
+            <span data-testid="dashboard-operators-table-row-balance-eth">
+              {formatETH(balanceEth)}
+            </span>
           </div>
           {balanceSSV > 0 && (
             <div className="flex items-center gap-1 text-gray-800 font-medium">
@@ -61,12 +71,14 @@ export const OperatorTableRow: FCProps = ({
                 src="/images/ssvIcons/icon.svg"
                 className="size-5"
               />{" "}
-              {formatSSV(balanceSSV)}
+              <span data-testid="dashboard-operators-table-row-balance-ssv">
+                {formatSSV(balanceSSV)}
+              </span>
             </div>
           )}
         </div>
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-yearly-fee">
         <div className="flex items-center gap-2 w-max">
           <div className="flex items-center gap-1 text-gray-800 font-medium">
             <img
@@ -74,7 +86,9 @@ export const OperatorTableRow: FCProps = ({
               src="/images/networks/dark.svg"
               className="size-5"
             />{" "}
-            {formatETH(yearlyFeeEth)}
+            <span data-testid="dashboard-operators-table-row-yearly-fee-eth">
+              {formatETH(yearlyFeeEth)}
+            </span>
           </div>
           {yearlyFeeSSV > 0 && (
             <div className="flex items-center gap-1 text-gray-800 font-medium">
@@ -84,13 +98,17 @@ export const OperatorTableRow: FCProps = ({
                 src="/images/ssvIcons/icon.svg"
                 className="size-5"
               />{" "}
-              {formatSSV(yearlyFeeSSV)}
+              <span data-testid="dashboard-operators-table-row-yearly-fee-ssv">
+                {formatSSV(yearlyFeeSSV)}
+              </span>
             </div>
           )}
         </div>
       </TableCell>
-      <TableCell>{operator.validators_count}</TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-validators-count">
+        {operator.validators_count}
+      </TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-effective-balance">
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-1 text-gray-800 font-medium">
             <img

--- a/src/components/operator/operators-table/operators-table.tsx
+++ b/src/components/operator/operators-table/operators-table.tsx
@@ -78,22 +78,48 @@ export const OperatorsTable: FCProps = ({
     );
   };
   return (
-    <div className="flex flex-col w-full">
+    <div
+      data-testid="dashboard-operators-table"
+      className="flex flex-col w-full"
+    >
       <Table
         className={cn(className, "w-full rounded-t-xl overflow-hidden")}
         {...props}
       >
         <TableHeader>
-          <TableHead>Operator name</TableHead>
-          <TableHead>Status</TableHead>
-          <TableHead>{renderSortableHeader({ type: "performance30d", title: "30D Performance" })}</TableHead>
-          <TableHead>Balance (ETH | SSV)</TableHead>
-          <TableHead>Yearly Fee (ETH | SSV)</TableHead>
-          <TableHead>{renderSortableHeader({ type: "validatorsCount", title: "Validators" })}</TableHead>
-          <TableHead>{renderSortableHeader({ type: "effectiveBalance", title: "Total ETH Managed" })}</TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-name">
+            Operator name
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-status">
+            Status
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-performance">
+            {renderSortableHeader({
+              type: "performance30d",
+              title: "30D Performance",
+            })}
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-balance">
+            Balance (ETH | SSV)
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-yearly-fee">
+            Yearly Fee (ETH | SSV)
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-validators">
+            {renderSortableHeader({
+              type: "validatorsCount",
+              title: "Validators",
+            })}
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-effective-balance">
+            {renderSortableHeader({
+              type: "effectiveBalance",
+              title: "Total ETH Managed",
+            })}
+          </TableHead>
         </TableHeader>
         <TableBody>
-          {operators.map((operator) => {
+          {operators.map((operator, index) => {
             const { queryKey } = getOperatorQueryOptions(operator.id);
             const cachedOperator = queryClient.getQueryData(queryKey);
             if (cachedOperator?.is_deleted) return null;
@@ -102,6 +128,7 @@ export const OperatorsTable: FCProps = ({
               <OperatorTableRow
                 key={operator.id}
                 operator={operator}
+                rowIndex={index}
                 onClick={() => {
                   return onOperatorClick(operator);
                 }}

--- a/src/components/validator/clusters-table/clusters-table-row.tsx
+++ b/src/components/validator/clusters-table/clusters-table-row.tsx
@@ -24,6 +24,7 @@ import { Link, useLocation } from "react-router-dom";
 
 export type ClustersTableRowProps = {
   cluster: Cluster;
+  rowIndex?: number;
 };
 
 type FCProps = FC<
@@ -31,7 +32,12 @@ type FCProps = FC<
     ClustersTableRowProps
 >;
 
-export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
+export const ClustersTableRow: FCProps = ({
+  cluster,
+  rowIndex,
+  className,
+  ...props
+}) => {
   const location = useLocation();
   const from = `${location.pathname}${location.search}${location.hash}`;
 
@@ -53,18 +59,21 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
   return (
     <TableRow
       key={cluster.id}
+      data-testid="dashboard-clusters-table-row"
+      data-testid-index={rowIndex}
+      data-testid-entity={cluster.clusterId}
       className={cn("cursor-pointer", className, {
         "bg-warning-200": runway.data?.isAtRisk,
         "bg-error-50": isLiquidated,
       })}
       {...props}
     >
-      <TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-name">
         <div className="max-w-[88px] truncate">
           {resolvedCluster.name || shortenClusterId(cluster.clusterId)}
         </div>
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-operators">
         <div className="flex gap-[2px]">
           {cluster.operators.map((o) => {
             const Cmp: FC = () => {
@@ -100,14 +109,16 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
           })}
         </div>
       </TableCell>
-      <TableCell>{resolvedCluster.validatorCount}</TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-validators-count">
+        {resolvedCluster.validatorCount}
+      </TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-effective-balance">
         <div className="flex items-center gap-1 text-gray-800 font-medium">
           <img src="/images/networks/dark.svg" className="size-5" />{" "}
           {formatEffectiveBalance(BigInt(effectiveBalance))}
         </div>
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-balance">
         {isSsvCluster ? (
           <div className="flex items-center gap-1 text-gray-800 font-medium">
             <img src="/images/ssvIcons/icon.svg" className="size-5" />{" "}
@@ -120,7 +131,7 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
           </div>
         )}
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-runway">
         {isLoadingRunway ? (
           <Skeleton className="h-5 w-14" />
         ) : resolvedCluster.validatorCount > 0 ? (
@@ -129,15 +140,26 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
           "-"
         )}
       </TableCell>
-      <TableCell className="whitespace-nowrap">
+      <TableCell
+        data-testid="dashboard-clusters-table-row-status"
+        className="whitespace-nowrap"
+      >
         {isLiquidated ? (
-          <Badge size="sm" variant="error">
+          <Badge
+            data-testid="dashboard-clusters-table-row-liquidated-badge"
+            size="sm"
+            variant="error"
+          >
             Liquidated
           </Badge>
         ) : isLoadingRunway ? null : (
           <>
             {runway.data?.isAtRisk && (
-              <Badge size="sm" variant="warning">
+              <Badge
+                data-testid="dashboard-clusters-table-row-low-runway-badge"
+                size="sm"
+                variant="warning"
+              >
                 Low runway
               </Badge>
             )}
@@ -147,6 +169,7 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
       <TableCell>
         {isSsvCluster && (
           <Button
+            data-testid="dashboard-clusters-table-row-switch-to-eth-btn"
             as={Link}
             to={`/switch-wizard/${cluster.clusterId}`}
             state={{ from }}

--- a/src/components/validator/clusters-table/clusters-table.tsx
+++ b/src/components/validator/clusters-table/clusters-table.tsx
@@ -101,13 +101,13 @@ export const ClusterTable: FCProps = ({
   };
 
   return (
-    <div className="flex flex-col w-full">
+    <div data-testid="dashboard-clusters-table" className="flex flex-col w-full">
       <Table
         className={cn(className, "w-full rounded-t-xl overflow-hidden")}
         {...props}
       >
         <TableHeader>
-          <TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-cluster">
             <Tooltip
               asChild
               content={
@@ -115,6 +115,7 @@ export const ClusterTable: FCProps = ({
                   Clusters represent a unique set of operators who operate your
                   validators and can be represented by ID or a name.{" "}
                   <Button
+                    data-testid="dashboard-clusters-table-header-cluster-more-link"
                     as={Link}
                     to={links.MORE_ON_CLUSTERS}
                     target="_blank"
@@ -136,30 +137,37 @@ export const ClusterTable: FCProps = ({
               })}
             </Tooltip>
           </TableHead>
-          <TableHead>Operators</TableHead>
-          <TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-operators">
+            Operators
+          </TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-validators">
             {renderSortableHeader({
               type: "validatorCount",
               title: "Validators",
             })}
           </TableHead>
-          <TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-effective-balance">
             {renderSortableHeader({
               type: "effectiveBalance",
               title: "Total Effective Balance",
             })}
           </TableHead>
-          <TableHead>Cluster Balance</TableHead>
-          <TableHead>Operational Runway</TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-cluster-balance">
+            Cluster Balance
+          </TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-operational-runway">
+            Operational Runway
+          </TableHead>
           <TableHead />
           <TableHead />
         </TableHeader>
         <TableBody>
-          {clusters.map((cluster) => {
+          {clusters.map((cluster, index) => {
             return (
               <ClustersTableRow
                 key={cluster.id}
                 cluster={cluster}
+                rowIndex={index}
                 onClick={() => onClusterClick(cluster)}
               />
             );
@@ -169,13 +177,20 @@ export const ClusterTable: FCProps = ({
 
       <div className="bg-gray-50 w-full">{isLoading && <Loading />}</div>
       {isEmpty ? (
-        <div className="flex flex-col items-center justify-center gap-4 w-full bg-gray-50 py-16 rounded-b-2xl">
+        <div
+          data-testid="dashboard-clusters-empty-state"
+          className="flex flex-col items-center justify-center gap-4 w-full bg-gray-50 py-16 rounded-b-2xl"
+        >
           <LogoIcon className="size-20" />
           <div className="flex flex-col items-center gap-2">
-            <Text variant="body-2-medium">
+            <Text
+              data-testid="dashboard-clusters-empty-message"
+              variant="body-2-medium"
+            >
               You don't have any clusters yet.
             </Text>
             <Button
+              data-testid="dashboard-clusters-empty-create-btn"
               as={Link}
               to="/join/validator"
               size="lg"


### PR DESCRIPTION
## Summary

Second PR in the QA test-IDs initiative. Tags every interactive element + key value display across the dashboard so Andrew's automation suite can target stable selectors.

**Stacked on PR #1867** (shared UI composites). Retarget to \`stage\` once PR 1 merges.

## Coverage

- **List pages:** clusters, operators
- **Detail pages:** cluster (SSV + Migrated variants), operator
- **Cluster sub-pages:** deposit, withdraw, exit confirmation, exit success, remove confirmation, bulk select (exit/remove)
- **Operator sub-pages:** settings (metadata, authorized addresses, external contract, status), update-fee (root, decrease, increase, success), withdraw, remove, not-your-operator, not-found
- **Dashboard chrome:** dashboard picker, cluster header, cluster name dialog, operational runway card
- **Tables:** clusters table, operators table, cluster operators table, cluster validators list, bulk select table

## Naming conventions

- All dashboard IDs are prefixed \`dashboard-\` then sectioned by feature (\`-cluster-\`, \`-operator-\`, \`-clusters-\`, \`-operators-\`)
- Row IDs follow the agreed pattern: \`<page>-<entity>-row\` + \`data-testid-index={n}\` + \`data-testid-entity={stable-id}\`
- Entity IDs per [memory contract](../memory/test_id_conventions.md):
  - Validator rows → \`data-testid-entity\` = full pubkey (0x… 96 chars)
  - Operator rows → numeric operator ID
  - Cluster rows → full cluster hash (0x… 64 chars)

## Reference

The new \`TEST_IDS.md\` section "Dashboard" enumerates every ID added in this PR, grouped per page.

## Verification

- \`pnpm type-check\` passes
- \`pnpm lint\` passes (1 pre-existing unrelated warning)
- No behavior changes; only attribute additions

## Test plan

- [ ] Deploy to staging, spot-check that pagination/tables/modals still work normally
- [ ] DOM check: \`document.querySelectorAll('[data-testid^="dashboard-"]').length\` should return >100 across the dashboard surface
- [ ] Verify row identity attribute exists on each table: \`document.querySelectorAll('[data-testid-entity]')\`

## Follow-up PRs

3. Create-cluster wizard
4. Switch-wizard
5. Join (operator onboarding)
6. Reshare-DKG
7. Modals + banners + remaining (connect-wallet, compliance, maintenance, not-found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)