### PR TITLE
chore(qa): add data-testid attributes across the entire app for QA automation

### DIFF
--- a/src/app/routes/compliance.tsx
+++ b/src/app/routes/compliance.tsx
@@ -16,24 +16,30 @@ export const Compliance: FC = () => {
 
   return (
     <Container
+      data-testid="compliance-page"
       variant="vertical"
       className="max-w-screen-2xl w-full p-6 items-center h-full"
     >
       <div className="flex flex-1 justify-center items-center flex-col">
         <img src="/images/complianceRobot.svg" alt="Maintenance" className="w-40" />
-        <Text variant="headline2" className="text-gray-700 mt-16">
+        <Text
+          data-testid="compliance-title"
+          variant="headline2"
+          className="text-gray-700 mt-16"
+        >
           Website not available
         </Text>
         <div className="flex flex-col gap-2 text-center mt-7">
-          <Text variant="body-2-semibold">
+          <Text data-testid="compliance-location" variant="body-2-semibold">
             We noticed you are located in {compliance.data}
           </Text>
-          <Text variant="body-2-medium">
+          <Text data-testid="compliance-description" variant="body-2-medium">
             Please note that the website{" "}
             <span className="text-primary-500">{window.location.host}</span> is
             not available in your country
           </Text>
           <Button
+            data-testid="compliance-learn-more-link"
             className="mt-2"
             variant="link"
             as="a"

--- a/src/app/routes/connect-wallet/connect-wallet.tsx
+++ b/src/app/routes/connect-wallet/connect-wallet.tsx
@@ -14,16 +14,26 @@ export const ConnectWallet: FC<ComponentPropsWithoutRef<"div">> = () => {
   }
 
   return (
-    <Card className="max-w-[648px] mx-auto p-8 gap-8">
+    <Card
+      data-testid="connect-wallet-page"
+      className="max-w-[648px] mx-auto p-8 gap-8"
+    >
       <div className="flex flex-col gap-4">
-        <Text variant="headline1"> Welcome to SSV Network</Text>
-        <Text variant="body-2-medium" className="text-gray-700">
+        <Text data-testid="connect-wallet-title" variant="headline1">
+          {" "}
+          Welcome to SSV Network
+        </Text>
+        <Text
+          data-testid="connect-wallet-description"
+          variant="body-2-medium"
+          className="text-gray-700"
+        >
           Connect your wallet to run distributed validators, or join as an
           operator.
         </Text>
       </div>
       <img src={robotRocket} className="h-[274px] mx-auto" />
-      <ConnectWalletBtn size="xl" />
+      <ConnectWalletBtn data-testid="connect-wallet-btn" size="xl" />
     </Card>
   );
 };

--- a/src/app/routes/create-cluster/additional-funding.tsx
+++ b/src/app/routes/create-cluster/additional-funding.tsx
@@ -65,8 +65,15 @@ export const AdditionalFunding: FC = () => {
   });
 
   return (
-    <Container variant="vertical" className="p-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="create-cluster-additional-funding-page"
+      variant="vertical"
+      className="p-6"
+    >
+      <NavigateBackBtn
+        data-testid="create-cluster-additional-funding-back-btn"
+        by="history"
+      />
       <Form {...form}>
         <Card as="form" onSubmit={submit}>
           <CardHeader
@@ -103,6 +110,7 @@ export const AdditionalFunding: FC = () => {
                       >
                         <div className="flex gap-2">
                           <input
+                            data-testid="create-cluster-additional-funding-no-radio"
                             id="current-balance"
                             type="radio"
                             checked={!field.value}
@@ -124,6 +132,7 @@ export const AdditionalFunding: FC = () => {
                       >
                         <div className="flex gap-2">
                           <input
+                            data-testid="create-cluster-additional-funding-yes-radio"
                             id="top-up-balance"
                             type="radio"
                             checked={field.value}
@@ -146,6 +155,7 @@ export const AdditionalFunding: FC = () => {
                                   rightSlot={
                                     <div className="flex items-center gap-2">
                                       <Button
+                                        data-testid="create-cluster-additional-funding-max-btn"
                                         size="sm"
                                         className="h-auto py-1.5"
                                         variant="subtle"
@@ -184,6 +194,7 @@ export const AdditionalFunding: FC = () => {
             />
           </UnmountClosed>
           <Button
+            data-testid="create-cluster-additional-funding-next-btn"
             type="submit"
             size="xl"
             disabled={

--- a/src/app/routes/create-cluster/balance-warning.tsx
+++ b/src/app/routes/create-cluster/balance-warning.tsx
@@ -13,8 +13,15 @@ export const BalanceWarning: FC = () => {
   const [agree2, setAgree2] = useState(false);
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="create-cluster-balance-warning-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="create-cluster-balance-warning-back-btn"
+        by="history"
+      />
       <Card>
         <CardHeader
           title="Cluster Balances and Fees"
@@ -50,6 +57,7 @@ export const BalanceWarning: FC = () => {
         <div className="flex flex-col gap-3">
           <label htmlFor="agree-1" className="flex gap-2 items-center">
             <Checkbox
+              data-testid="create-cluster-balance-warning-fees-checkbox"
               checked={agree1}
               id="agree-1"
               onCheckedChange={(checked: boolean) => setAgree1(checked)}
@@ -60,6 +68,7 @@ export const BalanceWarning: FC = () => {
           </label>
           <label htmlFor="agree-2" className="flex gap-2 items-center">
             <Checkbox
+              data-testid="create-cluster-balance-warning-liquidation-checkbox"
               checked={agree2}
               id="agree-2"
               onCheckedChange={(checked: boolean) => setAgree2(checked)}
@@ -70,6 +79,7 @@ export const BalanceWarning: FC = () => {
           </label>
         </div>
         <Button
+          data-testid="create-cluster-balance-warning-next-btn"
           as={Link}
           to="../slashing-warning"
           size="xl"

--- a/src/app/routes/create-cluster/distribute-offline.tsx
+++ b/src/app/routes/create-cluster/distribute-offline.tsx
@@ -40,14 +40,27 @@ export const DistributeOffline: FC = () => {
       : health.hasUnhealthyOperators) || health.hasVersionMismatch;
 
   return (
-    <Container size="lg" variant="vertical" className="py-6">
-      <NavigateBackBtn by="path" to="../distribution-method" />
+    <Container
+      data-testid="create-cluster-distribute-offline-page"
+      size="lg"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="create-cluster-distribute-offline-back-btn"
+        by="path"
+        to="../distribution-method"
+      />
       <Card className="w-full">
-        <Text variant="headline4">
+        <Text
+          data-testid="create-cluster-distribute-offline-title"
+          variant="headline4"
+        >
           How do you want to generate your keyshares?
         </Text>
         <div className="flex gap-6">
           <SelectionCard
+            data-testid="create-cluster-distribute-offline-cli-card"
             icon={<Cmd />}
             title="Command Line Interface"
             description="Generate from Existing Key"
@@ -55,6 +68,7 @@ export const DistributeOffline: FC = () => {
             onClick={() => setSelectedOption("existing")}
           />
           <SelectionCard
+            data-testid="create-cluster-distribute-offline-dkg-card"
             icon={<Dkg />}
             title="DKG"
             description="Generate from New Key"
@@ -72,6 +86,7 @@ export const DistributeOffline: FC = () => {
             />
             {!inCluster && (
               <Button
+                data-testid="create-cluster-distribute-offline-change-operators-btn"
                 as={Link}
                 to="../select-operators?has_dkg_address=true"
                 size="xl"

--- a/src/app/routes/create-cluster/distribution-method.tsx
+++ b/src/app/routes/create-cluster/distribution-method.tsx
@@ -27,8 +27,15 @@ export const DistributionMethod: FC<Props> = ({ variant = "create" }) => {
       : "/join/validator/select-operators";
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn to={prevPath} />
+    <Container
+      data-testid="create-cluster-distribution-method-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="create-cluster-distribution-method-back-btn"
+        to={prevPath}
+      />
       <Card className="font-medium">
         <CardHeader
           title="Generate Validator KeyShares"
@@ -50,7 +57,13 @@ export const DistributionMethod: FC<Props> = ({ variant = "create" }) => {
           <div className="flex [&>*]:flex-1 gap-3">
             {chain?.testnet && (
               <div className="flex flex-col gap-2">
-                <Button as={Link} to="../online" variant="secondary" size="xl">
+                <Button
+                  data-testid="create-cluster-distribution-method-online-btn"
+                  as={Link}
+                  to="../online"
+                  variant="secondary"
+                  size="xl"
+                >
                   Online
                 </Button>
                 {variant === "create" && (
@@ -64,7 +77,13 @@ export const DistributionMethod: FC<Props> = ({ variant = "create" }) => {
               </div>
             )}
             <div className="flex flex-col gap-2">
-              <Button as={Link} to="../offline" variant="secondary" size="xl">
+              <Button
+                data-testid="create-cluster-distribution-method-offline-btn"
+                as={Link}
+                to="../offline"
+                variant="secondary"
+                size="xl"
+              >
                 Offline
               </Button>
               {variant === "create" && (
@@ -79,6 +98,7 @@ export const DistributionMethod: FC<Props> = ({ variant = "create" }) => {
           </div>
           {variant === "add" && (
             <Button
+              data-testid="create-cluster-distribution-method-have-keyshares-btn"
               as={Link}
               to="../keyshares"
               variant="secondary"

--- a/src/app/routes/create-cluster/generate-key-shares-online.tsx
+++ b/src/app/routes/create-cluster/generate-key-shares-online.tsx
@@ -109,8 +109,15 @@ export const GenerateKeySharesOnline: FCProps = () => {
   };
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="create-cluster-generate-online-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="create-cluster-generate-online-back-btn"
+        by="history"
+      />
       <Card className="flex flex-col w-full">
         <CardHeader
           title="Enter Validator Key"
@@ -146,6 +153,7 @@ export const GenerateKeySharesOnline: FCProps = () => {
                   </FormLabel>
                   <FormControl>
                     <Input
+                      data-testid="create-cluster-generate-online-password-input"
                       {...field}
                       disabled={status !== "validator-not-registered"}
                       type="password"
@@ -175,6 +183,7 @@ export const GenerateKeySharesOnline: FCProps = () => {
               </AlertDescription>
             </Alert>
             <Button
+              data-testid="create-cluster-generate-online-submit-btn"
               size="xl"
               type="submit"
               disabled={

--- a/src/app/routes/create-cluster/initial-funding.tsx
+++ b/src/app/routes/create-cluster/initial-funding.tsx
@@ -125,11 +125,23 @@ export const InitialFunding: FCProps = ({ ...props }) => {
   }
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="create-cluster-initial-funding-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="create-cluster-initial-funding-back-btn"
+        by="history"
+      />
       <Form {...form}>
         <Card as="form" onSubmit={submit} {...props}>
-          <Text variant="headline4">Select your validator funding period</Text>
+          <Text
+            data-testid="create-cluster-initial-funding-title"
+            variant="headline4"
+          >
+            Select your validator funding period
+          </Text>
           <Text variant="body-2-medium">
             The ETH amount you deposit will determine your validator operational
             runway (You can always manage it later by withdrawing or depositing
@@ -277,7 +289,11 @@ export const InitialFunding: FCProps = ({ ...props }) => {
             fundingDays={days}
             effectiveBalance={effectiveBalance}
           />
-          <Button size="xl" type="submit">
+          <Button
+            data-testid="create-cluster-initial-funding-next-btn"
+            size="xl"
+            type="submit"
+          >
             Next
           </Button>
         </Card>

--- a/src/app/routes/create-cluster/launchpad.tsx
+++ b/src/app/routes/create-cluster/launchpad.tsx
@@ -9,10 +9,22 @@ import { NavigateBackBtn } from "@/components/ui/navigate-back-btn";
 export const Launchpad: FC = () => {
   const links = useLinks();
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="create-cluster-launchpad-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="create-cluster-launchpad-back-btn"
+        by="history"
+      />
       <Card className="w-full">
-        <Text variant="headline4">Visit Ethereum Launchpad</Text>
+        <Text
+          data-testid="create-cluster-launchpad-title"
+          variant="headline4"
+        >
+          Visit Ethereum Launchpad
+        </Text>
         <div className="space-y-2">
           <Text variant="body-2-medium">
             You must have an active validator before running it on the SSV
@@ -32,7 +44,13 @@ export const Launchpad: FC = () => {
           className="h-[150px] mx-auto my-4"
           alt="rhino"
         />
-        <Button as="a" href={links.launchpad} target="_blank" size="xl">
+        <Button
+          data-testid="create-cluster-launchpad-visit-btn"
+          as="a"
+          href={links.launchpad}
+          target="_blank"
+          size="xl"
+        >
           Visit Ethereum Launchpad
         </Button>
       </Card>

--- a/src/app/routes/create-cluster/preparation.tsx
+++ b/src/app/routes/create-cluster/preparation.tsx
@@ -23,8 +23,15 @@ type FCProps = FC<
 export const Preparation: FCProps = ({ className, ...props }) => {
   const { isNewAccount, accountRoutePath } = useAccountState();
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn to={(isNewAccount && accountRoutePath) || "/clusters"} />
+    <Container
+      data-testid="create-cluster-preparation-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="create-cluster-preparation-back-btn"
+        to={(isNewAccount && accountRoutePath) || "/clusters"}
+      />
       <Card className={cn(className)} {...props}>
         <CardHeader
           title="Run a Distributed Validator"
@@ -63,10 +70,21 @@ export const Preparation: FCProps = ({ className, ...props }) => {
           </div>
         </div>
         <div className="flex flex-col w-full gap-3">
-          <Button as={Link} to="select-operators" size="xl">
+          <Button
+            data-testid="create-cluster-preparation-generate-keyshares-btn"
+            as={Link}
+            to="select-operators"
+            size="xl"
+          >
             Generate new key shares
           </Button>
-          <Button as={Link} to="keyshares" size="xl" variant="secondary">
+          <Button
+            data-testid="create-cluster-preparation-have-keyshares-btn"
+            as={Link}
+            to="keyshares"
+            size="xl"
+            variant="secondary"
+          >
             I already have key shares
           </Button>
         </div>

--- a/src/app/routes/create-cluster/register-validator-confirmation.tsx
+++ b/src/app/routes/create-cluster/register-validator-confirmation.tsx
@@ -143,13 +143,30 @@ export const RegisterValidatorConfirmation: FC = () => {
   };
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="create-cluster-register-confirmation-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="create-cluster-register-confirmation-back-btn"
+        by="history"
+      />
       <Card className="w-full">
         <div className="flex justify-between w-full">
-          <Text variant="headline4">Transaction Details</Text>
+          <Text
+            data-testid="create-cluster-register-confirmation-title"
+            variant="headline4"
+          >
+            Transaction Details
+          </Text>
           {isBulk && (
-            <Badge variant="success">{shares.length} Validators</Badge>
+            <Badge
+              data-testid="create-cluster-register-confirmation-validators-count-badge"
+              variant="success"
+            >
+              {shares.length} Validators
+            </Badge>
           )}
         </div>
         {shares.length === 1 && (
@@ -157,7 +174,11 @@ export const RegisterValidatorConfirmation: FC = () => {
             <Text variant="body-3-semibold" className="text-gray-500">
               Validator Public Key
             </Text>
-            <Input disabled value={shares[0].publicKey} />
+            <Input
+              data-testid="create-cluster-register-confirmation-pubkey-input"
+              disabled
+              value={shares[0].publicKey}
+            />
           </div>
         )}
         <div className="space-y-2">
@@ -196,6 +217,7 @@ export const RegisterValidatorConfirmation: FC = () => {
         )}
         {/*<WithAllowance size="xl" amount={depositAmount}>*/}
         <Button
+          data-testid="create-cluster-register-confirmation-submit-btn"
           size="xl"
           isLoading={isPending}
           isActionBtn

--- a/src/app/routes/create-cluster/register-validator-success.tsx
+++ b/src/app/routes/create-cluster/register-validator-success.tsx
@@ -28,9 +28,18 @@ export const RegisterValidatorSuccess: FC = () => {
   if (!operatorIds.length) return <Navigate to="/clusters" />;
 
   return (
-    <Container variant="vertical" className="py-6">
+    <Container
+      data-testid="create-cluster-register-success-page"
+      variant="vertical"
+      className="py-6"
+    >
       <Card>
-        <Text variant="headline4">Welcome to the SSV Network!</Text>
+        <Text
+          data-testid="create-cluster-register-success-title"
+          variant="headline4"
+        >
+          Welcome to the SSV Network!
+        </Text>
         <Text variant="body-2-medium">
           Your new validator is managed by the following cluster:
         </Text>
@@ -77,7 +86,12 @@ export const RegisterValidatorSuccess: FC = () => {
           Your cluster operators have been notified and will start your
           validator operation instantly.
         </Text>
-        <Button as={Link} to={`/clusters/${clusterHash}`} size="xl">
+        <Button
+          data-testid="create-cluster-register-success-manage-cluster-btn"
+          as={Link}
+          to={`/clusters/${clusterHash}`}
+          size="xl"
+        >
           Manage Cluster
         </Button>
       </Card>

--- a/src/app/routes/create-cluster/select-operators/index.tsx
+++ b/src/app/routes/create-cluster/select-operators/index.tsx
@@ -155,6 +155,7 @@ export const SelectOperators: FCProps = ({ className, ...props }) => {
 
   return (
     <Container
+      data-testid="create-cluster-select-operators-page"
       variant="vertical"
       className="py-6 "
       size="xl"
@@ -162,10 +163,15 @@ export const SelectOperators: FCProps = ({ className, ...props }) => {
       navigateRoutePath={`/clusters/${clusterHash}/reshare`}
       onBackButtonClick={stepBack}
     >
-      {!reshareFlow.operators.length && <NavigateBackBtn />}
+      {!reshareFlow.operators.length && (
+        <NavigateBackBtn data-testid="create-cluster-select-operators-back-btn" />
+      )}
       <div className="flex items-stretch flex-1 gap-6 w-full">
         <Card className={cn(className, "flex flex-col flex-[2.2]")} {...props}>
-          <Text variant="headline4">
+          <Text
+            data-testid="create-cluster-select-operators-title"
+            variant="headline4"
+          >
             Pick the cluster of network operators to run your validator
           </Text>
           <OperatorClusterSizePicker
@@ -174,6 +180,7 @@ export const SelectOperators: FCProps = ({ className, ...props }) => {
           />
           <div className="flex gap-2">
             <SearchInput
+              data-testid="create-cluster-select-operators-search-input"
               value={search}
               onChange={(e) => setSearch(e.target.value as string)}
             />
@@ -278,6 +285,7 @@ export const SelectOperators: FCProps = ({ className, ...props }) => {
             </Alert>
           )}
           <Button
+            data-testid="create-cluster-select-operators-next-btn"
             size="xl"
             as={Link}
             isLoading={cluster.isLoading || operatorsUsability.isLoading}

--- a/src/app/routes/create-cluster/slashing-warning.tsx
+++ b/src/app/routes/create-cluster/slashing-warning.tsx
@@ -16,11 +16,23 @@ export const SlashingWarning: FC = () => {
   const { shares } = useRegisterValidatorContext();
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="create-cluster-slashing-warning-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="create-cluster-slashing-warning-back-btn"
+        by="history"
+      />
       <Card className="font-medium">
         <div className="space-y-2">
-          <Text variant="headline4">Slashing Warning</Text>
+          <Text
+            data-testid="create-cluster-slashing-warning-title"
+            variant="headline4"
+          >
+            Slashing Warning
+          </Text>
           {shares.length === 1 && (
             <>
               <Text className="font-semibold text-sm text-gray-500 w-fit">
@@ -49,6 +61,7 @@ export const SlashingWarning: FC = () => {
         </Text>
         <label htmlFor="agree-1" className="flex gap-3">
           <Checkbox
+            data-testid="create-cluster-slashing-warning-agreement-checkbox"
             checked={agree1}
             id="agree-1"
             className="mt-1"
@@ -59,7 +72,13 @@ export const SlashingWarning: FC = () => {
             setups will cause slashing to my validator
           </Text>
         </label>
-        <Button as={Link} to="../confirmation" size="xl" disabled={!agree1}>
+        <Button
+          data-testid="create-cluster-slashing-warning-next-btn"
+          as={Link}
+          to="../confirmation"
+          size="xl"
+          disabled={!agree1}
+        >
           Next
         </Button>
       </Card>

--- a/src/app/routes/create-cluster/upload-keyshares.tsx
+++ b/src/app/routes/create-cluster/upload-keyshares.tsx
@@ -120,14 +120,23 @@ export const UploadKeyshares: FCProps = ({ ...props }) => {
 
   return (
     <Container
+      data-testid="create-cluster-upload-keyshares-page"
       variant="vertical"
       size={validators.data?.sharesWithStatuses?.length ? "xl" : "default"}
       className="h-full py-6"
     >
-      <NavigateBackBtn by="history" />
+      <NavigateBackBtn
+        data-testid="create-cluster-upload-keyshares-back-btn"
+        by="history"
+      />
       <div className="flex gap-6 w-full">
         <Card className="flex-1 h-fit" {...props}>
-          <Text variant="headline4">Enter KeyShares File</Text>
+          <Text
+            data-testid="create-cluster-upload-keyshares-title"
+            variant="headline4"
+          >
+            Enter KeyShares File
+          </Text>
           <JSONFileUploader
             files={context.keysharesFile.files ?? []}
             onValueChange={(files) => {
@@ -217,6 +226,7 @@ export const UploadKeyshares: FCProps = ({ ...props }) => {
               </Text>
               <div className="flex items-center gap-1 justify-between">
                 <Button
+                  data-testid="create-cluster-upload-keyshares-decrement-btn"
                   disabled={context.selectedValidatorsCount <= 1}
                   variant="secondary"
                   onClick={() =>
@@ -229,6 +239,7 @@ export const UploadKeyshares: FCProps = ({ ...props }) => {
                   -
                 </Button>
                 <Input
+                  data-testid="create-cluster-upload-keyshares-count-input"
                   className="w-16 px-0"
                   inputProps={{ className: "text-center" }}
                   value={context.selectedValidatorsCount}
@@ -245,6 +256,7 @@ export const UploadKeyshares: FCProps = ({ ...props }) => {
                   }}
                 />
                 <Button
+                  data-testid="create-cluster-upload-keyshares-increment-btn"
                   disabled={context.selectedValidatorsCount === maxAddable}
                   onClick={() =>
                     (state.selectedValidatorsCount = Math.min(
@@ -288,6 +300,7 @@ export const UploadKeyshares: FCProps = ({ ...props }) => {
               selectedAmount={context.selectedValidatorsCount}
             />
             <Button
+              data-testid="create-cluster-upload-keyshares-next-btn"
               isLoading={cluster.isLoading}
               size="xl"
               onClick={submit}

--- a/src/app/routes/dashboard/clusters/cluster/bulk.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/bulk.tsx
@@ -55,16 +55,31 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
 
   // TODO: fetch validators to get status
   return (
-    <Container variant="vertical" size="lg" className="py-6 h-full">
-      <NavigateBackBtn to={`/clusters/${clusterHash}`} persistSearch />
+    <Container
+      data-testid={`dashboard-cluster-bulk-${type}-page`}
+      variant="vertical"
+      size="lg"
+      className="py-6 h-full"
+    >
+      <NavigateBackBtn
+        data-testid={`dashboard-cluster-bulk-${type}-back-btn`}
+        to={`/clusters/${clusterHash}`}
+        persistSearch
+      />
       <Card className="w-full flex-1 flex flex-col gap-4">
         <div className="flex justify-between">
-          <Text variant="headline4">
+          <Text
+            data-testid={`dashboard-cluster-bulk-${type}-title`}
+            variant="headline4"
+          >
             {type === "remove"
               ? "Select validators to Remove"
               : "Select validators to Exit"}
           </Text>
-          <Badge variant="primary">
+          <Badge
+            data-testid={`dashboard-cluster-bulk-${type}-selected-count`}
+            variant="primary"
+          >
             {selectedPublicKeys.length} of {totalValidators} selected
           </Badge>
         </div>
@@ -76,6 +91,7 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
           headers={[
             <div className="size-5">
               <Checkbox
+                data-testid={`dashboard-cluster-bulk-${type}-select-all-checkbox`}
                 checked={isAllChecked}
                 onClick={() => {
                   if (!isAllChecked) {
@@ -103,6 +119,9 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
           renderRow={({ index, item }) => (
             <TableRow
               as="label"
+              data-testid={`dashboard-cluster-bulk-${type}-row`}
+              data-testid-index={index}
+              data-testid-entity={item.public_key}
               className="select-none cursor-pointer"
               htmlFor={item.public_key}
               key={index}
@@ -110,6 +129,7 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
             >
               <TableCell className="flex gap-2 items-center">
                 <Checkbox
+                  data-testid={`dashboard-cluster-bulk-${type}-row-checkbox`}
                   id={item.public_key}
                   checked={selectedPublicKeys.includes(item.public_key)}
                   onCheckedChange={() =>
@@ -121,17 +141,32 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
                 />
               </TableCell>
               <TableCell className="flex gap-2 items-center">
-                <Text variant="body-2-medium">
+                <Text
+                  data-testid={`dashboard-cluster-bulk-${type}-row-pubkey`}
+                  variant="body-2-medium"
+                >
                   {shortenAddress(add0x(item.public_key))}
                 </Text>
-                <CopyBtn variant="subtle" text={item.public_key} />
+                <CopyBtn
+                  data-testid={`dashboard-cluster-bulk-${type}-row-pubkey-copy-btn`}
+                  variant="subtle"
+                  text={item.public_key}
+                />
               </TableCell>
               <TableCell>
-                <ValidatorStatusBadge size="sm" status={item.displayedStatus} />
+                <ValidatorStatusBadge
+                  data-testid={`dashboard-cluster-bulk-${type}-row-status`}
+                  size="sm"
+                  status={item.displayedStatus}
+                />
               </TableCell>
               <TableCell className="flex gap-1 justify-end">
-                <SsvExplorerBtn validatorId={item.public_key} />
+                <SsvExplorerBtn
+                  data-testid={`dashboard-cluster-bulk-${type}-row-explorer-btn`}
+                  validatorId={item.public_key}
+                />
                 <Button
+                  data-testid={`dashboard-cluster-bulk-${type}-row-beaconchain-btn`}
                   as="a"
                   size="icon"
                   className="size-7 text-gray-700"
@@ -146,6 +181,7 @@ export const Bulk: FC<{ type: "remove" | "exit" }> = ({ type }) => {
           )}
         />
         <Button
+          data-testid={`dashboard-cluster-bulk-${type}-next-btn`}
           as={Link}
           to={`/clusters/${clusterHash}/${type}/confirmation`}
           size="xl"

--- a/src/app/routes/dashboard/clusters/cluster/cluster.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/cluster.tsx
@@ -62,8 +62,16 @@ export const Cluster: FC = () => {
         backRoutePath="/clusters"
         backButtonLabel="Cluster Details"
       />
-      <Container variant="vertical" size="xl" className="min-h-full py-6">
-        <div className="grid grid-cols-4 gap-6 w-full">
+      <Container
+        data-testid="dashboard-cluster-page"
+        variant="vertical"
+        size="xl"
+        className="min-h-full py-6"
+      >
+        <div
+          data-testid="dashboard-cluster-operators-stats"
+          className="grid grid-cols-4 gap-6 w-full"
+        >
           {cluster.data?.operators.map((operator) => (
             <OperatorStatCard
               isClusterMigrated={isMigrated}
@@ -74,18 +82,33 @@ export const Cluster: FC = () => {
           ))}
         </div>
         <div className="flex flex-1 items-start gap-6 w-full">
-          <Card className="flex-[1]">
+          <Card data-testid="dashboard-cluster-balance-card" className="flex-[1]">
             <div className="flex flex-col gap-2 ">
               <div className="flex gap-2 items-center">
-                <Text variant="headline4" className="text-gray-500">
+                <Text
+                  data-testid="dashboard-cluster-balance-label"
+                  variant="headline4"
+                  className="text-gray-500"
+                >
                   Balance
                 </Text>
-                {isLiquidated.data && <Badge variant="error">Liquidated</Badge>}
+                {isLiquidated.data && (
+                  <Badge
+                    data-testid="dashboard-cluster-liquidated-badge"
+                    variant="error"
+                  >
+                    Liquidated
+                  </Badge>
+                )}
               </div>
               {balance.isLoading ? (
                 <Skeleton className="h-10 w-24 my-1" />
               ) : (
-                <BalanceDisplay amount={balance.data} token={balance.token} />
+                <BalanceDisplay
+                  data-testid="dashboard-cluster-balance-display"
+                  amount={balance.data}
+                  token={balance.token}
+                />
               )}
             </div>
             {Boolean(cluster.data?.validatorCount) && (
@@ -105,11 +128,17 @@ export const Cluster: FC = () => {
 
             {isLiquidated.data ? (
               isMigrated ? (
-                <Button as={Link} to="reactivate-balance" size="xl">
+                <Button
+                  data-testid="dashboard-cluster-reactivate-btn"
+                  as={Link}
+                  to="reactivate-balance"
+                  size="xl"
+                >
                   Reactivate Cluster
                 </Button>
               ) : (
                 <Button
+                  data-testid="dashboard-cluster-switch-to-eth-btn-liquidated"
                   as={Link}
                   to={`/switch-wizard/${clusterHash}`}
                   state={{ from }}
@@ -123,6 +152,7 @@ export const Cluster: FC = () => {
                 <div className="flex gap-6 [&>*]:flex-1">
                   <SwitchToEthMenuOptionTooltip asChild enabled={!isMigrated}>
                     <Button
+                      data-testid="dashboard-cluster-deposit-btn"
                       as={Link}
                       to="deposit"
                       size="xl"
@@ -131,12 +161,19 @@ export const Cluster: FC = () => {
                       Deposit
                     </Button>
                   </SwitchToEthMenuOptionTooltip>
-                  <Button as={Link} to="withdraw" size="xl" variant="secondary">
+                  <Button
+                    data-testid="dashboard-cluster-withdraw-btn"
+                    as={Link}
+                    to="withdraw"
+                    size="xl"
+                    variant="secondary"
+                  >
                     Withdraw
                   </Button>
                 </div>
                 {!isMigrated && (
                   <Button
+                    data-testid="dashboard-cluster-switch-to-eth-btn-live"
                     as={Link}
                     to={`/switch-wizard/${clusterHash}`}
                     state={{ from }}
@@ -149,12 +186,24 @@ export const Cluster: FC = () => {
               </div>
             )}
           </Card>
-          <Card className="flex-[2] h-full">
+          <Card
+            data-testid="dashboard-cluster-validators-card"
+            className="flex-[2] h-full"
+          >
             <div className="flex w-full gap-2 justify-between">
-              <Text variant="headline4" className="text-gray-500">
+              <Text
+                data-testid="dashboard-cluster-validators-label"
+                variant="headline4"
+                className="text-gray-500"
+              >
                 Validators
               </Text>
-              <Badge size="sm" variant="primary" className="h-fit">
+              <Badge
+                data-testid="dashboard-cluster-validators-count"
+                size="sm"
+                variant="primary"
+                className="h-fit"
+              >
                 {cluster.data?.validatorCount}
               </Badge>
               <Spacer />
@@ -164,6 +213,7 @@ export const Cluster: FC = () => {
               />
               <Tooltip content={getTooltipContent()}>
                 <Button
+                  data-testid="dashboard-cluster-add-validator-btn"
                   disabled={
                     operatorsUsability.isError ||
                     operatorsUsability.data?.hasExceededValidatorsLimit ||

--- a/src/app/routes/dashboard/clusters/cluster/deposit-cluster-balance.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/deposit-cluster-balance.tsx
@@ -66,11 +66,19 @@ export const DepositClusterBalance: FC = () => {
   });
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-cluster-deposit-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="dashboard-cluster-deposit-back-btn" />
       <Form {...form}>
         <Card as="form" className="w-full" onSubmit={submit}>
-          <Text variant="headline4" className="text-gray-500">
+          <Text
+            data-testid="dashboard-cluster-deposit-title"
+            variant="headline4"
+            className="text-gray-500"
+          >
             Deposit
           </Text>
           <FormField
@@ -110,6 +118,7 @@ export const DepositClusterBalance: FC = () => {
                       <div className="flex flex-col pl-6 pr-5 py-4 gap-3 rounded-xl border border-gray-300 bg-gray-200">
                         <div className="flex h-14 items-center gap-5">
                           <input
+                            data-testid="dashboard-cluster-deposit-amount-input"
                             placeholder="0"
                             className="w-full h-full border outline-none flex-1 text-[28px] font-medium border-none bg-transparent"
                             {...props}
@@ -120,6 +129,7 @@ export const DepositClusterBalance: FC = () => {
                         <Divider />
                         <div className="flex justify-end">
                           <Text
+                            data-testid="dashboard-cluster-deposit-wallet-balance"
                             variant="body-2-medium"
                             className="text-gray-500"
                           >
@@ -144,6 +154,7 @@ export const DepositClusterBalance: FC = () => {
           )}
 
           <Button
+            data-testid="dashboard-cluster-deposit-submit-btn"
             type="submit"
             size="xl"
             disabled={!isChanged}

--- a/src/app/routes/dashboard/clusters/cluster/exit-validators-confirmation.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/exit-validators-confirmation.tsx
@@ -71,18 +71,25 @@ export const ExitValidatorsConfirmation: FC = () => {
 
   return (
     <Container
+      data-testid="dashboard-cluster-exit-confirmation-page"
       variant="vertical"
       size="xl"
       className="p-6 font-medium w-[1096px]"
     >
-      <NavigateBackBtn by="history" />
+      <NavigateBackBtn
+        data-testid="dashboard-cluster-exit-back-btn"
+        by="history"
+      />
       <div className="flex w-full gap-6">
         <Card className="flex-[1.7]">
           <CardHeader
             title="Exit validators"
             description="Exiting your validator signals to the network that you wish to permanently cease your validator's participation in the Beacon Chain and retrieve your 32 ETH stake principal."
           />
-          <Text className="text-gray-600">
+          <Text
+            data-testid="dashboard-cluster-exit-queue-info"
+            className="text-gray-600"
+          >
             Initiating an exit places your validator in the exit queue. The
             duration in the queue depends on the number of validators already
             waiting. During this period, your validator must remain active, so
@@ -90,13 +97,14 @@ export const ExitValidatorsConfirmation: FC = () => {
             registered with the SSV network until it has fully exited.
           </Text>
           <Alert variant="warning">
-            <AlertDescription>
+            <AlertDescription data-testid="dashboard-cluster-exit-warning">
               Exiting your validator from the Beacon Chain is permanent and
               cannot be reversed, preventing any future reactivation.
             </AlertDescription>
           </Alert>
           <label htmlFor="agree-1" className="flex gap-3">
             <Checkbox
+              data-testid="dashboard-cluster-exit-agree-1-checkbox"
               checked={agree1}
               id="agree-1"
               className="mt-1"
@@ -109,6 +117,7 @@ export const ExitValidatorsConfirmation: FC = () => {
           </label>
           <label htmlFor="agree-2" className="flex gap-3">
             <Checkbox
+              data-testid="dashboard-cluster-exit-agree-2-checkbox"
               checked={agree2}
               id="agree-2"
               className="mt-1"
@@ -122,6 +131,7 @@ export const ExitValidatorsConfirmation: FC = () => {
           </label>
           <label htmlFor="agree-3" className="flex gap-3">
             <Checkbox
+              data-testid="dashboard-cluster-exit-agree-3-checkbox"
               checked={agree3}
               id="agree-3"
               className="mt-1"
@@ -134,6 +144,7 @@ export const ExitValidatorsConfirmation: FC = () => {
             </Text>
           </label>
           <Button
+            data-testid="dashboard-cluster-exit-submit-btn"
             size="xl"
             disabled={!agree1 || !agree2 || !agree3}
             onClick={exit}

--- a/src/app/routes/dashboard/clusters/cluster/exit-validators-success.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/exit-validators-success.tsx
@@ -13,6 +13,7 @@ export const ExitValidatorsSuccess: FC = () => {
   const { selectedPublicKeys } = useBulkActionContext();
   return (
     <Container
+      data-testid="dashboard-cluster-exit-success-page"
       variant="horizontal"
       size="xl"
       className="p-6 font-medium w-[1096px]"
@@ -23,7 +24,9 @@ export const ExitValidatorsSuccess: FC = () => {
           description="Your request to exit the validator has been successfully broadcasted to the network."
         />
         <Divider />
-        <Text variant="headline4">Next Steps</Text>
+        <Text data-testid="dashboard-cluster-exit-success-next-steps-heading" variant="headline4">
+          Next Steps
+        </Text>
         <Text variant="body-2-medium">
           1. <Span variant="body-2-bold">Monitor Validator</Span>: Keep track of
           your validator until it fully exits.
@@ -35,7 +38,12 @@ export const ExitValidatorsSuccess: FC = () => {
           Keep in mind that you will continue to incur operational fees until
           it's removed, regardless of the validator's state on the Beacon Chain.
         </Text>
-        <Button as={Link} to="../.." size="xl">
+        <Button
+          data-testid="dashboard-cluster-exit-success-go-to-cluster-btn"
+          as={Link}
+          to="../.."
+          size="xl"
+        >
           Go to Cluster Page
         </Button>
       </Card>

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-header.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-header.tsx
@@ -41,10 +41,12 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
 
   return (
     <Card
+      data-testid="dashboard-migrated-cluster-header"
       className={cn("flex flex-row items-center gap-3 p-6 w-full", className)}
       {...props}
     >
       <Link
+        data-testid="dashboard-migrated-cluster-header-back-link"
         to="/clusters"
         className="flex items-center justify-center rounded-[6px] bg-gray-100 p-1.5"
       >
@@ -53,11 +55,16 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
 
       <div className="flex flex-1 items-center gap-5 min-w-0">
         <div className="flex items-center gap-2 min-w-0 overflow-hidden">
-          <Text variant="headline4" className="truncate">
+          <Text
+            data-testid="dashboard-migrated-cluster-header-name"
+            variant="headline4"
+            className="truncate"
+          >
             {clusterName || "Cluster"}
           </Text>
           {isOwner && (
             <button
+              data-testid="dashboard-migrated-cluster-header-edit-name-btn"
               onClick={() => setIsDialogOpen(true)}
               className="shrink-0 text-gray-400 hover:text-gray-600 transition-colors"
             >
@@ -72,16 +79,24 @@ export const ClusterHeader: FC<ComponentPropsWithoutRef<"div">> = ({
               ID:
             </Text>
             <Text
+              data-testid="dashboard-migrated-cluster-header-id"
               variant="body-3-medium"
               className="font-robotoMono text-gray-700"
             >
               {shortenClusterId(clusterId)}
             </Text>
-            <CopyBtn text={clusterId} />
+            <CopyBtn
+              data-testid="dashboard-migrated-cluster-header-id-copy-btn"
+              text={clusterId}
+            />
           </div>
 
           {isLiquidatedCluster && (
-            <Badge variant="error" size="xs">
+            <Badge
+              data-testid="dashboard-migrated-cluster-header-liquidated-badge"
+              variant="error"
+              size="xs"
+            >
               Liquidated
             </Badge>
           )}

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-name-dialog.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-name-dialog.tsx
@@ -109,13 +109,24 @@ export const ClusterNameDialog = ({
 
   return (
     <Dialog isOpen={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="w-[648px] max-w-[648px] gap-6 p-8">
-        <DialogClose className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 transition-colors">
+      <DialogContent
+        data-testid="cluster-name-dialog"
+        className="w-[648px] max-w-[648px] gap-6 p-8"
+      >
+        <DialogClose
+          data-testid="cluster-name-dialog-close-btn"
+          className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 transition-colors"
+        >
           <FaXmark className="size-4" />
         </DialogClose>
         <DialogHeader className="gap-3">
-          <DialogTitle>Cluster name</DialogTitle>
-          <p className="text-sm text-gray-700">
+          <DialogTitle data-testid="cluster-name-dialog-title">
+            Cluster name
+          </DialogTitle>
+          <p
+            data-testid="cluster-name-dialog-description"
+            className="text-sm text-gray-700"
+          >
             Set a display name for this cluster
           </p>
         </DialogHeader>
@@ -129,6 +140,7 @@ export const ClusterNameDialog = ({
                   <FormControl>
                     <div className="relative">
                       <Input
+                        data-testid="cluster-name-dialog-name-input"
                         placeholder="Cluster"
                         {...field}
                         onChange={(e) => {
@@ -146,6 +158,7 @@ export const ClusterNameDialog = ({
                       {field.value && (
                         <button
                           type="button"
+                          data-testid="cluster-name-dialog-clear-btn"
                           onClick={() => form.setValue("name", "", { shouldValidate: true, shouldDirty: true })}
                           className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-400 hover:text-gray-600 transition-colors"
                         >
@@ -156,9 +169,16 @@ export const ClusterNameDialog = ({
                   </FormControl>
                   {form.formState.dirtyFields.name &&
                     field.value.length > 0 &&
-                    !apiError && <FormMessage />}
+                    !apiError && (
+                      <FormMessage data-testid="cluster-name-dialog-name-error" />
+                    )}
                   {apiError && (
-                    <p className="text-sm text-error-500">{apiError}</p>
+                    <p
+                      data-testid="cluster-name-dialog-api-error"
+                      className="text-sm text-error-500"
+                    >
+                      {apiError}
+                    </p>
                   )}
                 </FormItem>
               )}
@@ -168,6 +188,7 @@ export const ClusterNameDialog = ({
               const isRemove = !!currentName && value === "";
               return (
                 <Button
+                  data-testid="cluster-name-dialog-submit-btn"
                   type="submit"
                   size="xl"
                   variant={isRemove ? "secondary" : "default"}

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-operators-table.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-operators-table.tsx
@@ -34,34 +34,38 @@ export const ClusterOperatorsTable: ClusterOperatorsTableFC = ({
 }) => {
   return (
     <Table
+      data-testid="dashboard-cluster-operators-table"
       gridTemplateColumns={GRID_COLUMNS}
       className={cn(className)}
       {...props}
     >
       <TableHeader>
-        <TableCell>
+        <TableCell data-testid="dashboard-cluster-operators-table-header-name">
           <Text variant="caption-medium" className="text-gray-500">
             Name
           </Text>
         </TableCell>
-        <TableCell>
+        <TableCell data-testid="dashboard-cluster-operators-table-header-status">
           <Text variant="caption-medium" className="text-gray-500">
             Status
           </Text>
         </TableCell>
-        <TableCell>
+        <TableCell data-testid="dashboard-cluster-operators-table-header-performance">
           <Text variant="caption-medium" className="text-gray-500">
             30D
           </Text>
         </TableCell>
-        <TableCell className="justify-end">
+        <TableCell
+          data-testid="dashboard-cluster-operators-table-header-fee"
+          className="justify-end"
+        >
           <Text variant="caption-medium" className="text-gray-500">
             1Y Fee
           </Text>
         </TableCell>
       </TableHeader>
-      {operators.map((operator) => (
-        <OperatorRow key={operator.id} operator={operator} />
+      {operators.map((operator, index) => (
+        <OperatorRow key={operator.id} operator={operator} rowIndex={index} />
       ))}
     </Table>
   );
@@ -69,7 +73,10 @@ export const ClusterOperatorsTable: ClusterOperatorsTableFC = ({
 
 ClusterOperatorsTable.displayName = "ClusterOperatorsTable";
 
-const OperatorRow: FC<{ operator: Operator }> = ({ operator }) => {
+const OperatorRow: FC<{ operator: Operator; rowIndex: number }> = ({
+  operator,
+  rowIndex,
+}) => {
   const isInactive = operator.is_active < 1;
   const yearlyFee = getYearlyFee(BigInt(operator.eth_fee), {
     format: true,
@@ -77,7 +84,12 @@ const OperatorRow: FC<{ operator: Operator }> = ({ operator }) => {
   });
 
   return (
-    <TableRow className="items-center h-[60px]">
+    <TableRow
+      data-testid="dashboard-cluster-operators-table-row"
+      data-testid-index={rowIndex}
+      data-testid-entity={operator.id}
+      className="items-center h-[60px]"
+    >
       <TableCell>
         <div className="flex items-center gap-3 min-w-0">
           <OperatorAvatar
@@ -88,6 +100,7 @@ const OperatorRow: FC<{ operator: Operator }> = ({ operator }) => {
           <div className="flex flex-col gap-0.5 min-w-0">
             <div className="flex items-center gap-1.5 h-3">
               <Text
+                data-testid="dashboard-cluster-operators-table-row-name"
                 variant="body-3-medium"
                 className="truncate"
                 title={operator.name}
@@ -95,28 +108,48 @@ const OperatorRow: FC<{ operator: Operator }> = ({ operator }) => {
                 {operator.name}
               </Text>
               {operator.type === "verified_operator" && (
-                <VerifiedSVG className="size-3.5 shrink-0" />
+                <VerifiedSVG
+                  data-testid="dashboard-cluster-operators-table-row-verified-icon"
+                  className="size-3.5 shrink-0"
+                />
               )}
-              <SsvExplorerBtn operatorId={operator.id} />
+              <SsvExplorerBtn
+                data-testid="dashboard-cluster-operators-table-row-explorer-btn"
+                operatorId={operator.id}
+              />
             </div>
             <div className="flex items-center gap-1">
-              <Text variant="caption-medium" className="text-gray-500">
+              <Text
+                data-testid="dashboard-cluster-operators-table-row-id"
+                variant="caption-medium"
+                className="text-gray-500"
+              >
                 ID: {operator.id}
               </Text>
-              <CopyBtn text={operator.id.toString()} />
+              <CopyBtn
+                data-testid="dashboard-cluster-operators-table-row-id-copy-btn"
+                text={operator.id.toString()}
+              />
             </div>
           </div>
         </div>
       </TableCell>
       <TableCell>
-        <OperatorStatusBadge size="xs" status={operator.status} />
+        <OperatorStatusBadge
+          data-testid="dashboard-cluster-operators-table-row-status"
+          size="xs"
+          status={operator.status}
+        />
       </TableCell>
       <TableCell
         className={cn({
           "text-error-500": isInactive,
         })}
       >
-        <Text variant="body-3-medium">
+        <Text
+          data-testid="dashboard-cluster-operators-table-row-performance"
+          variant="body-3-medium"
+        >
           {percentageFormatter.format(operator.performance["30d"])}
         </Text>
       </TableCell>
@@ -127,7 +160,12 @@ const OperatorRow: FC<{ operator: Operator }> = ({ operator }) => {
             src="/images/networks/dark.svg"
             className="size-5"
           />
-          <Text variant="body-3-medium">{yearlyFee}</Text>
+          <Text
+            data-testid="dashboard-cluster-operators-table-row-fee"
+            variant="body-3-medium"
+          >
+            {yearlyFee}
+          </Text>
         </div>
       </TableCell>
     </TableRow>

--- a/src/app/routes/dashboard/clusters/cluster/migrated/cluster-validators-list.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/cluster-validators-list.tsx
@@ -38,7 +38,10 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
   const isSsvCluster = !cluster.data?.migrated;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div
+      data-testid="dashboard-cluster-validators-list"
+      className="flex flex-col gap-4"
+    >
       <ValidatorsSearchAndFilters />
       <VirtualizedInfinityTable
         gridTemplateColumns="220px minmax(200px, auto) 120px"
@@ -59,24 +62,46 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
         ]}
         items={validators}
         renderRow={({ index, item }) => (
-          <TableRow key={index}>
+          <TableRow
+            data-testid="dashboard-cluster-validators-row"
+            data-testid-index={index}
+            data-testid-entity={item.public_key}
+            key={index}
+          >
             <TableCell className="flex gap-2 items-center">
-              <Text variant="body-2-medium">
+              <Text
+                data-testid="dashboard-cluster-validators-row-pubkey"
+                variant="body-2-medium"
+              >
                 {shortenAddress(add0x(item.public_key))}
               </Text>
-              <CopyBtn variant="subtle" text={item.public_key} />
+              <CopyBtn
+                data-testid="dashboard-cluster-validators-row-pubkey-copy-btn"
+                variant="subtle"
+                text={item.public_key}
+              />
             </TableCell>
             <TableCell>
-              <ValidatorStatusBadge size="sm" status={item.displayedStatus} />
+              <ValidatorStatusBadge
+                data-testid="dashboard-cluster-validators-row-status"
+                size="sm"
+                status={item.displayedStatus}
+              />
             </TableCell>
             <TableCell className="flex gap-0.5 justify-end">
-              <SsvExplorerBtn validatorId={item.public_key} />
-              <BeaconchainBtn validatorId={item.public_key} />
+              <SsvExplorerBtn
+                data-testid="dashboard-cluster-validators-row-explorer-btn"
+                validatorId={item.public_key}
+              />
+              <BeaconchainBtn
+                data-testid="dashboard-cluster-validators-row-beaconchain-btn"
+                validatorId={item.public_key}
+              />
 
               {cluster.data && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <IconButton>
+                    <IconButton data-testid="dashboard-cluster-validators-row-actions-trigger">
                       <HiOutlineCog />
                     </IconButton>
                   </DropdownMenuTrigger>
@@ -86,7 +111,10 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
                       target="_blank"
                       className={cn({ "pointer-events-none": isSsvCluster })}
                     >
-                      <DropdownMenuItem disabled={isSsvCluster}>
+                      <DropdownMenuItem
+                        data-testid="dashboard-cluster-validators-row-change-operators-item"
+                        disabled={isSsvCluster}
+                      >
                         <TbRefresh className="size-4" />
                         <span>Change Operators</span>
                         <Spacer />
@@ -94,6 +122,7 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
                       </DropdownMenuItem>
                     </a>
                     <DropdownMenuItem
+                      data-testid="dashboard-cluster-validators-row-remove-item"
                       onClick={() => {
                         useBulkActionContext.state.selectedPublicKeys = [
                           item.public_key,
@@ -115,6 +144,7 @@ export const ClusterValidatorsList: FC<ComponentPropsWithoutRef<"div">> = ({
                       }
                     >
                       <DropdownMenuItem
+                        data-testid="dashboard-cluster-validators-row-exit-item"
                         disabled={cluster.data?.isLiquidated}
                         onClick={() => {
                           useBulkActionContext.state.selectedPublicKeys = [

--- a/src/app/routes/dashboard/clusters/cluster/migrated/migrated-cluster.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/migrated-cluster.tsx
@@ -77,7 +77,12 @@ export const MigratedCluster: FC = () => {
 
   return (
     <>
-      <Container variant="vertical" size="xl" className="min-h-full py-6">
+      <Container
+        data-testid="dashboard-migrated-cluster-page"
+        variant="vertical"
+        size="xl"
+        className="min-h-full py-6"
+      >
         <ClusterHeader />
         <div className="flex flex-1 items-start gap-6 w-full">
           <div className="flex flex-[1] flex-col gap-6 min-w-0">
@@ -101,6 +106,7 @@ export const MigratedCluster: FC = () => {
             <div className="flex w-full gap-2 justify-between">
               <div className="flex gap-3 items-center">
                 <Tab
+                  data-testid="dashboard-migrated-cluster-tab-validators"
                   as={Link}
                   to={`/clusters/${clusterHash}`}
                   count={cluster.data?.validatorCount}
@@ -109,6 +115,7 @@ export const MigratedCluster: FC = () => {
                   Validators
                 </Tab>
                 <Tab
+                  data-testid="dashboard-migrated-cluster-tab-operators"
                   as={Link}
                   to={`/clusters/${clusterHash}/operators`}
                   count={cluster.data?.operators.length}
@@ -124,6 +131,7 @@ export const MigratedCluster: FC = () => {
               />
               <Tooltip content={getTooltipContent()}>
                 <Button
+                  data-testid="dashboard-migrated-cluster-add-validator-btn"
                   disabled={
                     operatorsUsability.isError ||
                     operatorsUsability.data?.hasExceededValidatorsLimit ||

--- a/src/app/routes/dashboard/clusters/cluster/migrated/operational-runway-card.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/migrated/operational-runway-card.tsx
@@ -69,20 +69,28 @@ export const OperationalRunwayCard: FC<OperationalRunwayCardProps> = ({
     (fundingCost.data?.subtotal.networkCost ?? 0n);
 
   return (
-    <Card className="w-full flex-1 p-6 gap-6">
+    <Card
+      data-testid="dashboard-operational-runway-card"
+      className="w-full flex-1 p-6 gap-6"
+    >
       <div className="flex items-center justify-between">
         <Tooltip
           className="max-w-[336px]"
           content="Estimated amount of days the cluster balance is sufficient to run all its validators"
         >
           <div className="flex items-center gap-1">
-            <Text variant="headline4" className="text-gray-500">
+            <Text
+              data-testid="dashboard-operational-runway-label"
+              variant="headline4"
+              className="text-gray-500"
+            >
               Est. Operational Runway
             </Text>
             <FaCircleInfo className="size-4 text-gray-500" />
           </div>
         </Tooltip>
         <Text
+          data-testid="dashboard-operational-runway-days"
           variant="headline4"
           className={cn(isProjected ? "text-primary-500" : "text-gray-700")}
         >
@@ -210,15 +218,31 @@ export const OperationalRunwayCard: FC<OperationalRunwayCardProps> = ({
         runway={runway?.runway ?? 0n}
       />
       {isLiquidated ? (
-        <Button as={Link} to="reactivate-balance" size="xl">
+        <Button
+          data-testid="dashboard-operational-runway-reactivate-btn"
+          as={Link}
+          to="reactivate-balance"
+          size="xl"
+        >
           Reactivate Cluster
         </Button>
       ) : (
         <div className="flex gap-3 [&>*]:flex-1 pt-2">
-          <Button as={Link} to="deposit" size="xl">
+          <Button
+            data-testid="dashboard-operational-runway-deposit-btn"
+            as={Link}
+            to="deposit"
+            size="xl"
+          >
             Deposit
           </Button>
-          <Button as={Link} to="withdraw" size="xl" variant="secondary">
+          <Button
+            data-testid="dashboard-operational-runway-withdraw-btn"
+            as={Link}
+            to="withdraw"
+            size="xl"
+            variant="secondary"
+          >
             Withdraw
           </Button>
         </div>

--- a/src/app/routes/dashboard/clusters/cluster/remove-validators-confirmation.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/remove-validators-confirmation.tsx
@@ -93,11 +93,15 @@ export const RemoveValidatorsConfirmation: FC = () => {
 
   return (
     <Container
+      data-testid="dashboard-cluster-remove-confirmation-page"
       variant="vertical"
       size="xl"
       className="p-6 font-medium w-[1096px]"
     >
-      <NavigateBackBtn by="history" />
+      <NavigateBackBtn
+        data-testid="dashboard-cluster-remove-back-btn"
+        by="history"
+      />
       <div className="flex w-full gap-6">
         <Card className="flex-[1.7]">
           <CardHeader
@@ -109,13 +113,14 @@ export const RemoveValidatorsConfirmation: FC = () => {
             network and does not exit your validator from the Beacon Chain.
           </Text>
           <Alert variant="warning">
-            <AlertDescription>
+            <AlertDescription data-testid="dashboard-cluster-remove-warning">
               To avoid slashing, it is advised to wait at least 2 epochs prior
               to running the validator on an alternative service.
             </AlertDescription>
           </Alert>
           <label htmlFor="agree-1" className="flex gap-3">
             <Checkbox
+              data-testid="dashboard-cluster-remove-agreement-checkbox"
               checked={agree1}
               id="agree-1"
               className="mt-1"
@@ -127,6 +132,7 @@ export const RemoveValidatorsConfirmation: FC = () => {
             </Text>
           </label>
           <Button
+            data-testid="dashboard-cluster-remove-submit-btn"
             size="xl"
             disabled={!agree1}
             onClick={remove}

--- a/src/app/routes/dashboard/clusters/cluster/withdraw-cluster-balance.tsx
+++ b/src/app/routes/dashboard/clusters/cluster/withdraw-cluster-balance.tsx
@@ -115,19 +115,30 @@ export const WithdrawClusterBalance: FC = () => {
   });
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-cluster-withdraw-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="dashboard-cluster-withdraw-back-btn" />
       <Card className="w-full gap-2">
         <Text variant="headline4" className="text-gray-500">
           Available Balance
         </Text>
-        <Text variant="headline1">
+        <Text
+          data-testid="dashboard-cluster-withdraw-available-balance"
+          variant="headline1"
+        >
           {formatSSV(clusterBalance)} {symbol}
         </Text>
       </Card>
       <Form {...form}>
         <Card as="form" className="w-full" onSubmit={submit}>
-          <Text variant="headline4" className="text-gray-500">
+          <Text
+            data-testid="dashboard-cluster-withdraw-title"
+            variant="headline4"
+            className="text-gray-500"
+          >
             Withdraw
           </Text>
           <FormField
@@ -146,6 +157,7 @@ export const WithdrawClusterBalance: FC = () => {
                       <div className="flex flex-col pl-6 pr-5 py-4 gap-3 rounded-xl border border-gray-300 bg-gray-200">
                         <div className="flex h-14 items-center gap-5">
                           <input
+                            data-testid="dashboard-cluster-withdraw-amount-input"
                             placeholder="0"
                             className="w-full h-full border outline-none flex-1 text-[28px] font-medium border-none bg-transparent"
                             {...props}
@@ -154,6 +166,7 @@ export const WithdrawClusterBalance: FC = () => {
                           />
                           {!isSsvCluster && (
                             <Button
+                              data-testid="dashboard-cluster-withdraw-max-btn"
                               size="lg"
                               variant="secondary"
                               className="font-semibold px-4"
@@ -192,13 +205,17 @@ export const WithdrawClusterBalance: FC = () => {
 
           {isSsvCluster && (
             <Alert variant="warning">
-              <AlertDescription className="flex flex-col gap-4">
+              <AlertDescription
+                data-testid="dashboard-cluster-withdraw-liquidation-warning"
+                className="flex flex-col gap-4"
+              >
                 <p>
                   Withdrawing from an SSV cluster is full-withdrawal only
                   (partial withdrawals aren't allowed). Proceeding will withdraw
                   the entire cluster balance and liquidate your cluster, which
                   will result in inactivation (
                   <Button
+                    data-testid="dashboard-cluster-withdraw-penalties-link"
                     variant="link"
                     as="a"
                     target="_blank"
@@ -210,6 +227,7 @@ export const WithdrawClusterBalance: FC = () => {
                   the network.
                 </p>
                 <Button
+                  data-testid="dashboard-cluster-withdraw-liquidation-docs-link"
                   variant="link"
                   as="a"
                   target="_blank"
@@ -224,6 +242,7 @@ export const WithdrawClusterBalance: FC = () => {
           {showRiskCheckbox && (
             <label className="flex items-center gap-2" id="understand">
               <Checkbox
+                data-testid="dashboard-cluster-withdraw-agreement-checkbox"
                 checked={hasAgreed}
                 id="understand"
                 className="border border-gray-500"
@@ -237,6 +256,7 @@ export const WithdrawClusterBalance: FC = () => {
             </label>
           )}
           <Button
+            data-testid="dashboard-cluster-withdraw-submit-btn"
             type="submit"
             size="xl"
             disabled={!isChanged || disabled}

--- a/src/app/routes/dashboard/clusters/clusters.tsx
+++ b/src/app/routes/dashboard/clusters/clusters.tsx
@@ -22,11 +22,17 @@ export const Clusters: FC<ComponentPropsWithoutRef<"div">> = () => {
         <title>SSV My Clusters</title>
       </Helmet>
 
-      <Container variant="vertical" size="xl" className="py-6">
+      <Container
+        data-testid="dashboard-clusters-page"
+        variant="vertical"
+        size="xl"
+        className="py-6"
+      >
         <div className="flex justify-between w-full gap-3">
           <DashboardPicker />
           <Spacer />
           <Button
+            data-testid="dashboard-clusters-fee-address-btn"
             size="lg"
             variant="secondary"
             as={Link}
@@ -35,7 +41,13 @@ export const Clusters: FC<ComponentPropsWithoutRef<"div">> = () => {
           >
             Fee Address <FiEdit3 />
           </Button>
-          <Button size="lg" className="px-10" as={Link} to="/join/validator">
+          <Button
+            data-testid="dashboard-clusters-add-cluster-btn"
+            size="lg"
+            className="px-10"
+            as={Link}
+            to="/join/validator"
+          >
             Add Cluster
           </Button>
         </div>

--- a/src/app/routes/dashboard/clusters/fee-recipient-address.tsx
+++ b/src/app/routes/dashboard/clusters/fee-recipient-address.tsx
@@ -97,8 +97,15 @@ export const FeeRecipientAddress: FC<ComponentPropsWithoutRef<"div">> = () => {
   });
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="dashboard-fee-recipient-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="dashboard-fee-recipient-back-btn"
+        by="history"
+      />
       <Form {...form}>
         <Card as="form" onSubmit={submit}>
           <CardHeader
@@ -108,6 +115,7 @@ export const FeeRecipientAddress: FC<ComponentPropsWithoutRef<"div">> = () => {
                 Enter an Ethereum address that will receive all of your
                 validators block proposal rewards.{" "}
                 <Button
+                  data-testid="dashboard-fee-recipient-proposal-rewards-link"
                   as={Link}
                   variant="link"
                   to="https://docs.ssv.network/stakers/validators/validator-rewards/"
@@ -121,7 +129,7 @@ export const FeeRecipientAddress: FC<ComponentPropsWithoutRef<"div">> = () => {
           />
 
           <Alert variant="warning">
-            <AlertDescription>
+            <AlertDescription data-testid="dashboard-fee-recipient-warning">
               Standard rewards from performing other duties will remain to be
               credited to your validators balance on the Beacon Chain.
             </AlertDescription>
@@ -131,19 +139,23 @@ export const FeeRecipientAddress: FC<ComponentPropsWithoutRef<"div">> = () => {
             name="feeRecipientAddress"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Fee Recipient Address</FormLabel>
+                <FormLabel data-testid="dashboard-fee-recipient-address-label">
+                  Fee Recipient Address
+                </FormLabel>
                 <FormControl>
                   <Input
+                    data-testid="dashboard-fee-recipient-address-input"
                     isLoading={ssvAccount.isLoading}
                     disabled={ssvAccount.isLoading}
                     {...field}
                   />
                 </FormControl>
-                <FormMessage />
+                <FormMessage data-testid="dashboard-fee-recipient-address-error" />
               </FormItem>
             )}
           />
           <Button
+            data-testid="dashboard-fee-recipient-update-btn"
             type="submit"
             size="xl"
             isLoading={setFeeRecipient.isPending}

--- a/src/app/routes/dashboard/operators/no-your-operator.tsx
+++ b/src/app/routes/dashboard/operators/no-your-operator.tsx
@@ -5,13 +5,28 @@ import { Text } from "@/components/ui/text";
 
 export const NoYourOperator: FC<ComponentPropsWithoutRef<"div">> = () => {
   return (
-    <div className="flex flex-col gap-4 items-center justify-center h-full">
+    <div
+      data-testid="dashboard-no-your-operator-page"
+      className="flex flex-col gap-4 items-center justify-center h-full"
+    >
       <div className="flex flex-col gap-1">
-        <Text variant="body-1-bold">Not your operator</Text>
-        <Text variant="body-3-medium" className="text-gray-500">
+        <Text data-testid="dashboard-no-your-operator-title" variant="body-1-bold">
+          Not your operator
+        </Text>
+        <Text
+          data-testid="dashboard-no-your-operator-description"
+          variant="body-3-medium"
+          className="text-gray-500"
+        >
           You are not authorized to access this operator.
         </Text>
-        <Button className="mt-4" as={Link} to="/operators" size="lg">
+        <Button
+          data-testid="dashboard-no-your-operator-back-btn"
+          className="mt-4"
+          as={Link}
+          to="/operators"
+          size="lg"
+        >
           Back to Operators Dashboard
         </Button>
       </div>

--- a/src/app/routes/dashboard/operators/operator-not-found.tsx
+++ b/src/app/routes/dashboard/operators/operator-not-found.tsx
@@ -5,13 +5,28 @@ import { Text } from "@/components/ui/text";
 
 export const OperatorNotFound: FC<ComponentPropsWithoutRef<"div">> = () => {
   return (
-    <div className="flex flex-col gap-4 items-center justify-center h-full">
+    <div
+      data-testid="dashboard-operator-not-found-page"
+      className="flex flex-col gap-4 items-center justify-center h-full"
+    >
       <div className="flex flex-col gap-1">
-        <Text variant="body-1-bold">Operator Not Found</Text>
-        <Text variant="body-3-medium" className="text-gray-500">
+        <Text data-testid="dashboard-operator-not-found-title" variant="body-1-bold">
+          Operator Not Found
+        </Text>
+        <Text
+          data-testid="dashboard-operator-not-found-description"
+          variant="body-3-medium"
+          className="text-gray-500"
+        >
           The operator you are looking for does not exist.
         </Text>
-        <Button className="mt-4" as={Link} to="/operators" size="lg">
+        <Button
+          data-testid="dashboard-operator-not-found-back-btn"
+          className="mt-4"
+          as={Link}
+          to="/operators"
+          size="lg"
+        >
           Back to Operators Dashboard
         </Button>
       </div>

--- a/src/app/routes/dashboard/operators/operator-settings/authorized-addresses.tsx
+++ b/src/app/routes/dashboard/operators/operator-settings/authorized-addresses.tsx
@@ -76,18 +76,31 @@ export const AuthorizedAddresses = () => {
         onCancel={unsavedChangesBlocker.reset}
       />
       <PastingLimitExceededModal />
-      <Container variant="vertical" size="lg" className="max-h-full py-10">
+      <Container
+        data-testid="dashboard-authorized-addresses-page"
+        variant="vertical"
+        size="lg"
+        className="max-h-full py-10"
+      >
         <Form {...addManager.form}>
-          <NavigateBackBtn />
+          <NavigateBackBtn data-testid="dashboard-authorized-addresses-back-btn" />
           <Card as="form" onSubmit={submit} className="w-full h overflow-auto">
             <div className="flex flex-col gap-2">
               <div className="flex justify-between items-center">
-                <h2 className="text-xl font-bold">Authorized Addresses</h2>
+                <h2
+                  data-testid="dashboard-authorized-addresses-title"
+                  className="text-xl font-bold"
+                >
+                  Authorized Addresses
+                </h2>
                 <Tooltip
                   asChild
                   content="The maximum number of addresses for whitelist is 500"
                 >
-                  <Badge variant="primary">
+                  <Badge
+                    data-testid="dashboard-authorized-addresses-count-badge"
+                    variant="primary"
+                  >
                     {totalAddresses} of 500 Addresses
                   </Badge>
                 </Tooltip>
@@ -134,10 +147,12 @@ export const AuthorizedAddresses = () => {
                     <FormItem>
                       <FormControl>
                         <Input
+                          data-testid={`dashboard-authorized-addresses-input-${index}`}
                           {...field}
                           onPaste={handlePaste(index)}
                           rightSlot={
                             <Button
+                              data-testid={`dashboard-authorized-addresses-remove-${index}-btn`}
                               variant="ghost"
                               size="icon"
                               onClick={() =>
@@ -168,6 +183,7 @@ export const AuthorizedAddresses = () => {
                   }
                 >
                   <button
+                    data-testid="dashboard-authorized-addresses-add-btn"
                     disabled={isAddBtnDisabled}
                     type="button"
                     className="sticky bottom-0 outline outline-[8px] outline-gray-50 bg-gray-50 h-12 w-full text-center border border-gray-400 border-dashed rounded-lg text-gray-500 font-medium"
@@ -182,6 +198,7 @@ export const AuthorizedAddresses = () => {
             {mode !== "view" && (
               <div className="flex gap-3 w-full">
                 <Button
+                  data-testid="dashboard-authorized-addresses-cancel-btn"
                   type="button"
                   className="flex-1"
                   size="xl"
@@ -192,6 +209,7 @@ export const AuthorizedAddresses = () => {
                   Cancel
                 </Button>
                 <Button
+                  data-testid="dashboard-authorized-addresses-submit-btn"
                   className="flex-1"
                   size="xl"
                   type="submit"

--- a/src/app/routes/dashboard/operators/operator-settings/external-contract.tsx
+++ b/src/app/routes/dashboard/operators/operator-settings/external-contract.tsx
@@ -148,9 +148,14 @@ export const ExternalContract: FC = () => {
   });
 
   return (
-    <Container variant="vertical" size="lg" className="py-6">
+    <Container
+      data-testid="dashboard-external-contract-page"
+      variant="vertical"
+      size="lg"
+      className="py-6"
+    >
       <Form {...form}>
-        <NavigateBackBtn />
+        <NavigateBackBtn data-testid="dashboard-external-contract-back-btn" />
         <Card>
           <form className="flex flex-col gap-8 w-full" onSubmit={submit}>
             <div className="flex flex-col gap-2">
@@ -198,11 +203,13 @@ export const ExternalContract: FC = () => {
                 <FormItem>
                   <FormControl>
                     <Input
+                      data-testid="dashboard-external-contract-input"
                       {...field}
                       placeholder="0xCONT...RACT"
                       rightSlot={
                         field.value && (
                           <Button
+                            data-testid="dashboard-external-contract-clear-btn"
                             variant="ghost"
                             size="icon"
                             onClick={() => field.onChange("")}
@@ -227,6 +234,7 @@ export const ExternalContract: FC = () => {
             {isChanged && (
               <div className="flex gap-3">
                 <Button
+                  data-testid="dashboard-external-contract-cancel-btn"
                   type="button"
                   disabled={isPending}
                   size="xl"
@@ -237,6 +245,7 @@ export const ExternalContract: FC = () => {
                   Cancel
                 </Button>
                 <Button
+                  data-testid="dashboard-external-contract-save-btn"
                   type="submit"
                   disabled={hasErrors}
                   isLoading={isPending}

--- a/src/app/routes/dashboard/operators/operator-settings/operator-metadata.tsx
+++ b/src/app/routes/dashboard/operators/operator-settings/operator-metadata.tsx
@@ -117,8 +117,13 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
       });
   };
   return (
-    <Container variant="vertical" className={cn(className, "py-6")} {...props}>
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-operator-metadata-page"
+      variant="vertical"
+      className={cn(className, "py-6")}
+      {...props}
+    >
+      <NavigateBackBtn data-testid="dashboard-operator-metadata-back-btn" />
       <Form {...form}>
         <Card as="form" className="w-full" onSubmit={form.handleSubmit(submit)}>
           <FormField
@@ -128,7 +133,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
               <FormItem>
                 <FormLabel>Operator name</FormLabel>
                 <FormControl>
-                  <Input placeholder="" {...field} />
+                  <Input
+                    data-testid="dashboard-operator-metadata-name-input"
+                    placeholder=""
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -167,7 +176,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
               <FormItem>
                 <FormLabel>Description</FormLabel>
                 <FormControl>
-                  <Textarea placeholder="Description" {...field} />
+                  <Textarea
+                    data-testid="dashboard-operator-metadata-description-input"
+                    placeholder="Description"
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -180,7 +193,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
               <FormItem>
                 <FormLabel>Cloud Provider</FormLabel>
                 <FormControl>
-                  <Input placeholder="AWS, Azure, Google Cloud..." {...field} />
+                  <Input
+                    data-testid="dashboard-operator-metadata-setup-provider-input"
+                    placeholder="AWS, Azure, Google Cloud..."
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -306,7 +323,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
               <FormItem>
                 <FormLabel>Website Link</FormLabel>
                 <FormControl>
-                  <Input placeholder="Enter your Website Link" {...field} />
+                  <Input
+                    data-testid="dashboard-operator-metadata-website-input"
+                    placeholder="Enter your Website Link"
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -320,7 +341,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
                 <FormItem>
                   <FormLabel>Twitter</FormLabel>
                   <FormControl>
-                    <Input placeholder="Enter your Twitter Link" {...field} />
+                    <Input
+                      data-testid="dashboard-operator-metadata-twitter-input"
+                      placeholder="Enter your Twitter Link"
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -335,7 +360,11 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
               <FormItem>
                 <FormLabel>Linkedin</FormLabel>
                 <FormControl>
-                  <Input placeholder="Enter your Linkedin Link" {...field} />
+                  <Input
+                    data-testid="dashboard-operator-metadata-linkedin-input"
+                    placeholder="Enter your Linkedin Link"
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -355,13 +384,18 @@ export const OperatorMetadata: FC<ComponentPropsWithoutRef<"div">> = ({
                   </FormLabel>
                 </Tooltip>
                 <FormControl>
-                  <Input placeholder="Enter your Website Link" {...field} />
+                  <Input
+                    data-testid="dashboard-operator-metadata-dkg-address-input"
+                    placeholder="Enter your Website Link"
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
             )}
           />
           <Button
+            data-testid="dashboard-operator-metadata-submit-btn"
             size="xl"
             isLoading={sign.isPending}
             type="submit"

--- a/src/app/routes/dashboard/operators/operator-settings/operator-settings.tsx
+++ b/src/app/routes/dashboard/operators/operator-settings/operator-settings.tsx
@@ -20,9 +20,17 @@ export const OperatorSettings: FC<ComponentPropsWithoutRef<"div">> = () => {
   );
 
   return (
-    <Container variant="vertical" className="mt-6" size="lg">
-      <NavigateBackBtn>{operator?.name}</NavigateBackBtn>
+    <Container
+      data-testid="dashboard-operator-settings-page"
+      variant="vertical"
+      className="mt-6"
+      size="lg"
+    >
+      <NavigateBackBtn data-testid="dashboard-operator-settings-back-btn">
+        {operator?.name}
+      </NavigateBackBtn>
       <Card
+        data-testid="dashboard-operator-settings-card"
         variant="unstyled"
         className="not-last:border-b not-last:border-gray-100 overflow-hidden"
       >

--- a/src/app/routes/dashboard/operators/operator-settings/operator-status.tsx
+++ b/src/app/routes/dashboard/operators/operator-settings/operator-status.tsx
@@ -46,12 +46,22 @@ export const OperatorStatus: FC = () => {
   };
 
   return (
-    <Container variant="vertical" size="lg" className="py-6">
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-operator-status-page"
+      variant="vertical"
+      size="lg"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="dashboard-operator-status-back-btn" />
       <Card>
         <div className="flex flex-col gap-8 w-full">
           <div className="flex flex-col gap-4">
-            <h1 className="text-xl font-bold">Operator Status</h1>
+            <h1
+              data-testid="dashboard-operator-status-title"
+              className="text-xl font-bold"
+            >
+              Operator Status
+            </h1>
             <div className="flex flex-col gap-3 font-medium text-sm text-gray-700">
               <p>
                 Control validator access by switching between public and private
@@ -87,6 +97,7 @@ export const OperatorStatus: FC = () => {
             </Alert>
           )}
           <Button
+            data-testid="dashboard-operator-status-toggle-btn"
             disabled={isFeeZero && operator?.is_private}
             size="xl"
             className="w-full"

--- a/src/app/routes/dashboard/operators/operator.tsx
+++ b/src/app/routes/dashboard/operators/operator.tsx
@@ -36,11 +36,16 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
       <Helmet>
         <title>SSV {operator.data?.name ?? ""}</title>
       </Helmet>
-      <div className="flex flex-col h-full gap-6 pb-6">
+      <div
+        data-testid="dashboard-operator-page"
+        className="flex flex-col h-full gap-6 pb-6"
+      >
         <div className="bg-gray-100 w-full h-[208px] pb-6">
           <Container size="xl" variant="vertical" className="pt-6">
             <div className="flex w-full items-center justify-between">
-              <NavigateBackBtn>Operator Details</NavigateBackBtn>
+              <NavigateBackBtn data-testid="dashboard-operator-back-btn">
+                Operator Details
+              </NavigateBackBtn>
               <OperatorSettingsBtn />
             </div>
             <div className="flex items-start flex-1 gap-20">
@@ -65,7 +70,10 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
                 <Text variant="body-3-medium" className="text-gray-500">
                   Validators
                 </Text>
-                <Text variant="body-2-medium">
+                <Text
+                  data-testid="dashboard-operator-validators-count"
+                  variant="body-2-medium"
+                >
                   {operator.data.validators_count}
                 </Text>
               </div>
@@ -73,7 +81,10 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
                 <Text variant="body-3-medium" className="text-gray-500">
                   30D Performance
                 </Text>
-                <Text variant="body-2-medium">
+                <Text
+                  data-testid="dashboard-operator-performance"
+                  variant="body-2-medium"
+                >
                   {percentageFormatter.format(operator.data.performance["30d"])}
                 </Text>
               </div>
@@ -87,7 +98,10 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
                     src="/images/networks/dark.svg"
                     className="size-5"
                   />
-                  <Text variant="body-2-medium">
+                  <Text
+                    data-testid="dashboard-operator-effective-balance"
+                    variant="body-2-medium"
+                  >
                     {operator.data.effective_balance} ETH
                   </Text>
                 </div>
@@ -97,19 +111,34 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
         </div>
         <Container variant="horizontal" size="xl" {...props} className="h-full">
           <div className="flex items-stretch gap-6 flex-col flex-1">
-            <Card className="w-full">
-              <Text variant="headline4" className="text-gray-500">
+            <Card data-testid="dashboard-operator-balance-card" className="w-full">
+              <Text
+                data-testid="dashboard-operator-balance-label"
+                variant="headline4"
+                className="text-gray-500"
+              >
                 Balance
               </Text>
               <div className="flex flex-col gap-4">
-                <BalanceDisplay amount={balanceEth} token="ETH" />
-                {yearlyFeeSSV !== 0n && !operator.data.migrated && <BalanceDisplay amount={balanceSSV} token="SSV" />}
+                <BalanceDisplay
+                  data-testid="dashboard-operator-balance-eth"
+                  amount={balanceEth}
+                  token="ETH"
+                />
+                {yearlyFeeSSV !== 0n && !operator.data.migrated && (
+                  <BalanceDisplay
+                    data-testid="dashboard-operator-balance-ssv"
+                    amount={balanceSSV}
+                    token="SSV"
+                  />
+                )}
               </div>
               <Tooltip
                 asChild
                 content={!hasBalance ? "No balance to withdraw" : undefined}
               >
                 <Button
+                  data-testid="dashboard-operator-withdraw-btn"
                   as={Link}
                   to="withdraw"
                   variant="default"
@@ -120,17 +149,29 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
                 </Button>
               </Tooltip>
             </Card>
-            <Card className="w-full">
+            <Card data-testid="dashboard-operator-fee-card" className="w-full">
               <div className="flex w-full justify-between items-center">
-                <Text variant="headline4" className="text-gray-500">
+                <Text
+                  data-testid="dashboard-operator-fee-label"
+                  variant="headline4"
+                  className="text-gray-500"
+                >
                   Annual Fee
                 </Text>
                 <IncreaseOperatorFeeStatusBadge />
               </div>
               <div className="flex flex-col gap-4">
-                <BalanceDisplay amount={yearlyFeeEth} token="ETH" />
+                <BalanceDisplay
+                  data-testid="dashboard-operator-yearly-fee-eth"
+                  amount={yearlyFeeEth}
+                  token="ETH"
+                />
                 {yearlyFeeSSV > 0 && (
-                  <BalanceDisplay amount={yearlyFeeSSV} token="SSV" />
+                  <BalanceDisplay
+                    data-testid="dashboard-operator-yearly-fee-ssv"
+                    amount={yearlyFeeSSV}
+                    token="SSV"
+                  />
                 )}
               </div>
               <Tooltip
@@ -153,6 +194,7 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
                 }
               >
                 <Button
+                  data-testid="dashboard-operator-update-fee-btn"
                   as={Link}
                   disabled={feeEth.isLoading || feeEth.data === 0n}
                   to="fee/update"
@@ -164,8 +206,15 @@ export const Operator: FC<ComponentPropsWithoutRef<"div">> = ({ ...props }) => {
               </Tooltip>
             </Card>
           </div>
-          <Card className="flex-[2] h-full max-h-[800px] overflow-auto">
-            <Text variant="headline4" className="text-gray-500">
+          <Card
+            data-testid="dashboard-operator-validators-card"
+            className="flex-[2] h-full max-h-[800px] overflow-auto"
+          >
+            <Text
+              data-testid="dashboard-operator-validators-label"
+              variant="headline4"
+              className="text-gray-500"
+            >
               Validators
             </Text>
             <OperatorValidatorsList />

--- a/src/app/routes/dashboard/operators/operators.tsx
+++ b/src/app/routes/dashboard/operators/operators.tsx
@@ -17,10 +17,21 @@ export const Operators: FC<ComponentPropsWithoutRef<"div">> = () => {
         <title>SSV My Operators</title>
       </Helmet>
 
-      <Container variant="vertical" size="xl" className="py-6">
+      <Container
+        data-testid="dashboard-operators-page"
+        variant="vertical"
+        size="xl"
+        className="py-6"
+      >
         <div className="flex justify-between w-full gap-3">
           <DashboardPicker />
-          <Button size="lg" as={Link} className="px-10" to="/join/operator">
+          <Button
+            data-testid="dashboard-operators-add-operator-btn"
+            size="lg"
+            as={Link}
+            className="px-10"
+            to="/join/operator"
+          >
             Add Operator
           </Button>
         </div>

--- a/src/app/routes/dashboard/operators/remove-operator.tsx
+++ b/src/app/routes/dashboard/operators/remove-operator.tsx
@@ -35,8 +35,12 @@ export const RemoveOperator: FC = () => {
   const [accepted, setAccepted] = useState(false);
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-remove-operator-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="dashboard-remove-operator-back-btn" />
       <Card>
         <CardHeader
           title="Remove Operator"
@@ -51,13 +55,14 @@ export const RemoveOperator: FC = () => {
           discoverable by other validators.
         </Text>
         <Alert variant="error">
-          <AlertDescription>
+          <AlertDescription data-testid="dashboard-remove-operator-warning">
             Please note that this process is irreversible and you would not be
             able to reactive this operator in the future.
           </AlertDescription>
         </Alert>
         <div className="flex gap-2">
           <Checkbox
+            data-testid="dashboard-remove-operator-agreement-checkbox"
             id="accept"
             checked={accepted}
             onCheckedChange={(checked: boolean) => setAccepted(checked)}
@@ -68,6 +73,7 @@ export const RemoveOperator: FC = () => {
           </Text>
         </div>
         <Button
+          data-testid="dashboard-remove-operator-submit-btn"
           variant="destructive"
           size="xl"
           onClick={remove}

--- a/src/app/routes/dashboard/operators/update-fee/decrease-operator-fee.tsx
+++ b/src/app/routes/dashboard/operators/update-fee/decrease-operator-fee.tsx
@@ -50,8 +50,12 @@ export const DecreaseOperatorFee: FC = () => {
   };
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn />
+    <Container
+      data-testid="dashboard-decrease-fee-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="dashboard-decrease-fee-back-btn" />
       <Card>
         <CardHeader
           title="Update Fee"
@@ -94,6 +98,7 @@ export const DecreaseOperatorFee: FC = () => {
           </Alert>
         )}
         <Button
+          data-testid="dashboard-decrease-fee-submit-btn"
           size="xl"
           isLoading={reduceOperatorFee.isPending}
           onClick={submit}

--- a/src/app/routes/dashboard/operators/update-fee/increase-operator-fee.tsx
+++ b/src/app/routes/dashboard/operators/update-fee/increase-operator-fee.tsx
@@ -90,6 +90,7 @@ export const IncreaseOperatorFee: FC = () => {
     if (isCanceled || status.isExpired)
       return (
         <Button
+          data-testid="dashboard-increase-fee-declare-new-btn"
           size="xl"
           isActionBtn
           onClick={() => {
@@ -105,6 +106,7 @@ export const IncreaseOperatorFee: FC = () => {
     if (status.isDeclaration)
       return (
         <Button
+          data-testid="dashboard-increase-fee-declare-btn"
           size="xl"
           isActionBtn
           onClick={declare}
@@ -118,6 +120,7 @@ export const IncreaseOperatorFee: FC = () => {
       return (
         <div className="flex gap-3">
           <Button
+            data-testid="dashboard-increase-fee-cancel-btn"
             size="xl"
             className="flex-1"
             variant="secondary"
@@ -128,6 +131,7 @@ export const IncreaseOperatorFee: FC = () => {
             Cancel
           </Button>
           <Button
+            data-testid="dashboard-increase-fee-execute-btn"
             size="xl"
             className="flex-1"
             disabled={status.isWaiting}
@@ -141,7 +145,12 @@ export const IncreaseOperatorFee: FC = () => {
     }
 
     return (
-      <Button as={Link} to="../.." size="xl">
+      <Button
+        data-testid="dashboard-increase-fee-back-to-account-btn"
+        as={Link}
+        to="../.."
+        size="xl"
+      >
         Back to my account
       </Button>
     );
@@ -199,8 +208,16 @@ export const IncreaseOperatorFee: FC = () => {
   };
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="path" to="../.." />
+    <Container
+      data-testid="dashboard-increase-fee-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="dashboard-increase-fee-back-btn"
+        by="path"
+        to="../.."
+      />
       <Card className="w-full gap-8">
         <CardHeader title="Update Fee" />
 

--- a/src/app/routes/dashboard/operators/update-fee/operator-fee-updated.tsx
+++ b/src/app/routes/dashboard/operators/update-fee/operator-fee-updated.tsx
@@ -9,7 +9,11 @@ import { Link } from "react-router-dom";
 export const OperatorFeeUpdated: FC = () => {
   const state = useUpdateOperatorFeeContext();
   return (
-    <Container variant="vertical" className="py-6">
+    <Container
+      data-testid="dashboard-fee-updated-page"
+      variant="vertical"
+      className="py-6"
+    >
       <Card>
         <CardHeader
           title="Update Fee"
@@ -19,7 +23,12 @@ export const OperatorFeeUpdated: FC = () => {
           previousFee={state.previousYearlyFee}
           newFee={state.newYearlyFee}
         />
-        <Button as={Link} to="/operators" size="xl">
+        <Button
+          data-testid="dashboard-fee-updated-back-to-account-btn"
+          as={Link}
+          to="/operators"
+          size="xl"
+        >
           Back To My Account
         </Button>
       </Card>

--- a/src/app/routes/dashboard/operators/update-fee/update-operator-fee.tsx
+++ b/src/app/routes/dashboard/operators/update-fee/update-operator-fee.tsx
@@ -102,8 +102,17 @@ export const UpdateOperatorFee: FC<ComponentPropsWithoutRef<"div">> = ({
   const isChanged = isBigIntChanged(form.watch("yearlyFee"), operatorYearlyFee);
 
   return (
-    <Container variant="vertical" className={cn(className, "py-6")} {...props}>
-      <NavigateBackBtn by="path" to="../.." />
+    <Container
+      data-testid="dashboard-update-fee-page"
+      variant="vertical"
+      className={cn(className, "py-6")}
+      {...props}
+    >
+      <NavigateBackBtn
+        data-testid="dashboard-update-fee-back-btn"
+        by="path"
+        to="../.."
+      />
       <Form {...form}>
         <Card as="form" className="w-full" onSubmit={submit}>
           <CardHeader
@@ -124,12 +133,14 @@ export const UpdateOperatorFee: FC<ComponentPropsWithoutRef<"div">> = ({
                       <div className="flex flex-col pl-6 pr-5 py-4 gap-3 rounded-xl border border-gray-300 bg-gray-200">
                         <div className="flex h-14 items-center gap-5">
                           <input
+                            data-testid="dashboard-update-fee-yearly-fee-input"
                             placeholder="0"
                             className="w-full h-full border outline-none flex-1 text-[28px] font-medium border-none bg-transparent"
                             {...props}
                             ref={ref}
                           />
                           <Button
+                            data-testid="dashboard-update-fee-max-btn"
                             size="lg"
                             variant="secondary"
                             className="font-semibold px-4"
@@ -187,6 +198,7 @@ export const UpdateOperatorFee: FC<ComponentPropsWithoutRef<"div">> = ({
             </Alert>
           )}
           <Button
+            data-testid="dashboard-update-fee-next-btn"
             size="xl"
             type="submit"
             isLoading={isLoading}

--- a/src/app/routes/dashboard/operators/withdraw-operator-balance.tsx
+++ b/src/app/routes/dashboard/operators/withdraw-operator-balance.tsx
@@ -71,20 +71,38 @@ export const WithdrawOperatorBalance: FC<ComponentPropsWithoutRef<"div">> = ({
   };
 
   return (
-    <Container variant="vertical" className={cn(className, "py-6")} {...props}>
+    <Container
+      data-testid="dashboard-withdraw-operator-page"
+      variant="vertical"
+      className={cn(className, "py-6")}
+      {...props}
+    >
       <Helmet>
         <title>Withdraw {operator?.name ?? ""}</title>
       </Helmet>
-      <NavigateBackBtn>{operator?.name}</NavigateBackBtn>
+      <NavigateBackBtn data-testid="dashboard-withdraw-operator-back-btn">
+        {operator?.name}
+      </NavigateBackBtn>
       <Card className="w-full">
         <Text variant="headline4" className="text-gray-500">
           Available Balance
         </Text>
         <div className="flex flex-col gap-4">
-          <BalanceDisplay amount={balanceEth} token="ETH" />
-          {hasSSVBalance && <BalanceDisplay amount={balanceSSV} token="SSV" />}
+          <BalanceDisplay
+            data-testid="dashboard-withdraw-operator-balance-eth"
+            amount={balanceEth}
+            token="ETH"
+          />
+          {hasSSVBalance && (
+            <BalanceDisplay
+              data-testid="dashboard-withdraw-operator-balance-ssv"
+              amount={balanceSSV}
+              token="SSV"
+            />
+          )}
         </div>
         <Button
+          data-testid="dashboard-withdraw-operator-submit-btn"
           disabled={!hasBalance}
           isActionBtn
           isLoading={withdraw.isPending}

--- a/src/app/routes/join/join.tsx
+++ b/src/app/routes/join/join.tsx
@@ -15,7 +15,7 @@ export const Join: FC<ComponentPropsWithoutRef<"div">> = ({
     return <Navigate to={accountRoutePath ?? "/my-account"} replace />;
   }
   return (
-    <Container variant="vertical" className="py-6">
+    <Container data-testid="join-page" variant="vertical" className="py-6">
       <Card className={cn(className)} {...props}>
         <CardHeader
           title="Join the SSV Network"
@@ -24,6 +24,7 @@ export const Join: FC<ComponentPropsWithoutRef<"div">> = ({
         <div className="flex gap-3">
           <div className="flex-1 flex gap-2 flex-col items-center">
             <Button
+              data-testid="join-distribute-validators-btn"
               as={Link}
               to="validator"
               size="xl"
@@ -35,6 +36,7 @@ export const Join: FC<ComponentPropsWithoutRef<"div">> = ({
           </div>
           <div className="flex-1 flex gap-2 flex-col items-center">
             <Button
+              data-testid="join-as-operator-btn"
               as={Link}
               to="operator"
               variant="secondary"

--- a/src/app/routes/join/operator/join-operator-preparation.tsx
+++ b/src/app/routes/join/operator/join-operator-preparation.tsx
@@ -15,8 +15,13 @@ export const JoinOperatorPreparation: FC<ComponentPropsWithoutRef<"div">> = ({
   const { isNewAccount, accountRoutePath } = useAccountState();
 
   return (
-    <Container variant="vertical" className="py-6">
+    <Container
+      data-testid="join-operator-preparation-page"
+      variant="vertical"
+      className="py-6"
+    >
       <NavigateBackBtn
+        data-testid="join-operator-preparation-back-btn"
         to={(isNewAccount && accountRoutePath) || "/operators"}
       ></NavigateBackBtn>
       <Card className={cn(className)} {...props}>
@@ -27,6 +32,7 @@ export const JoinOperatorPreparation: FC<ComponentPropsWithoutRef<"div">> = ({
         <div className="flex gap-3">
           <div className="flex-1 flex gap-2 flex-col items-center">
             <Button
+              data-testid="join-operator-preparation-run-node-btn"
               variant="secondary"
               size="xl"
               className="w-full"
@@ -42,6 +48,7 @@ export const JoinOperatorPreparation: FC<ComponentPropsWithoutRef<"div">> = ({
           </div>
           <div className="flex-1 flex gap-2 flex-col items-center">
             <Button
+              data-testid="join-operator-preparation-register-btn"
               as={Link}
               to="register"
               variant="secondary"

--- a/src/app/routes/join/operator/register-operator-confirmation.tsx
+++ b/src/app/routes/join/operator/register-operator-confirmation.tsx
@@ -94,8 +94,15 @@ export const RegisterOperatorConfirmation: FC = () => {
   useFocus("#register-operator-confirmation");
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="join-register-operator-confirmation-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="join-register-operator-confirmation-back-btn"
+        by="history"
+      />
       <Card
         id="register-operator-confirmation"
         as="form"
@@ -111,7 +118,12 @@ export const RegisterOperatorConfirmation: FC = () => {
           submit();
         }}
       >
-        <Text variant="headline4">Transaction Details</Text>
+        <Text
+          data-testid="join-register-operator-confirmation-title"
+          variant="headline4"
+        >
+          Transaction Details
+        </Text>
 
         <div className="flex flex-col gap-4">
           <div className="flex justify-between items-center gap-4">
@@ -169,6 +181,7 @@ export const RegisterOperatorConfirmation: FC = () => {
           </div>
         </div>
         <Button
+          data-testid="join-register-operator-confirmation-submit-btn"
           type="submit"
           size="xl"
           isLoading={register.isPending}

--- a/src/app/routes/join/operator/register-operator-success.tsx
+++ b/src/app/routes/join/operator/register-operator-success.tsx
@@ -21,7 +21,7 @@ export const RegisterOperatorSuccess: FC<
   }
 
   return (
-    <Container className="py-6">
+    <Container data-testid="join-register-operator-success-page" className="py-6">
       <Card className="relative overflow-hidden">
         <img
           src="/images/backgroundIcon/light.svg"
@@ -38,9 +38,22 @@ export const RegisterOperatorSuccess: FC<
           }
         />
         <div className="flex items-center gap-1">
-          <Text variant="body-1-medium">ID: {operatorId}</Text>
-          <CopyBtn className="size-8" text={operatorId} />
-          <SsvExplorerBtn className="size-8" operatorId={operatorId} />
+          <Text
+            data-testid="join-register-operator-success-id"
+            variant="body-1-medium"
+          >
+            ID: {operatorId}
+          </Text>
+          <CopyBtn
+            data-testid="join-register-operator-success-id-copy-btn"
+            className="size-8"
+            text={operatorId}
+          />
+          <SsvExplorerBtn
+            data-testid="join-register-operator-success-explorer-btn"
+            className="size-8"
+            operatorId={operatorId}
+          />
         </div>
         <Divider />
         <Text variant="body-2-semibold" className="text-gray-500">
@@ -48,6 +61,7 @@ export const RegisterOperatorSuccess: FC<
         </Text>
         <div className="p-4 py-8 border border-gray-300 rounded-lg">
           <Button
+            data-testid="join-register-operator-success-mev-link"
             variant="link"
             as={Link}
             to="https://docs.ssv.network/operators/operator-node/node-setup/configuring-mev/"
@@ -57,7 +71,12 @@ export const RegisterOperatorSuccess: FC<
           </Button>{" "}
           to propose MEV blocks for the validators you manage.
         </div>
-        <Button as={Link} size="xl" to={`/operators/${operatorId}`}>
+        <Button
+          data-testid="join-register-operator-success-manage-btn"
+          as={Link}
+          size="xl"
+          to={`/operators/${operatorId}`}
+        >
           Manage operator
         </Button>
       </Card>

--- a/src/app/routes/join/operator/register-operator.tsx
+++ b/src/app/routes/join/operator/register-operator.tsx
@@ -87,8 +87,14 @@ export const RegisterOperator: FC<ComponentPropsWithoutRef<"div">> = ({
   useFocus("#register-operator-public-key");
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn>Join the SSV Network Operators</NavigateBackBtn>
+    <Container
+      data-testid="join-register-operator-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn data-testid="join-register-operator-back-btn">
+        Join the SSV Network Operators
+      </NavigateBackBtn>
 
       <Form {...form}>
         <Card as="form" onSubmit={submit} className={cn(className)} {...props}>
@@ -109,7 +115,12 @@ export const RegisterOperator: FC<ComponentPropsWithoutRef<"div">> = ({
                   </FormLabel>
                 </Tooltip>
                 <FormControl>
-                  <Input disabled className="bg-gray-300" {...field} />
+                  <Input
+                    data-testid="join-register-operator-owner-input"
+                    disabled
+                    className="bg-gray-300"
+                    {...field}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -143,6 +154,7 @@ export const RegisterOperator: FC<ComponentPropsWithoutRef<"div">> = ({
 
                 <FormControl>
                   <Input
+                    data-testid="join-register-operator-pubkey-input"
                     id="register-operator-public-key"
                     {...field}
                     isLoading={fetchOperatorByPublicKey.isPending}
@@ -209,6 +221,7 @@ export const RegisterOperator: FC<ComponentPropsWithoutRef<"div">> = ({
                         isPrivate={form.watch("isPrivate")}
                       />
                       <Switch
+                        data-testid="join-register-operator-private-switch"
                         checked={form.watch("isPrivate")}
                         id="airplane-mode"
                         onCheckedChange={field.onChange}
@@ -221,6 +234,7 @@ export const RegisterOperator: FC<ComponentPropsWithoutRef<"div">> = ({
             />
           </div>
           <Button
+            data-testid="join-register-operator-submit-btn"
             size="xl"
             type="submit"
             disabled={!isEmpty(form.formState.errors)}

--- a/src/app/routes/join/operator/set-operator-fee.tsx
+++ b/src/app/routes/join/operator/set-operator-fee.tsx
@@ -101,8 +101,15 @@ export const SetOperatorFee: FC<ComponentPropsWithoutRef<"div">> = () => {
   useFocus("#register-operator-fee", { select: true });
 
   return (
-    <Container variant="vertical" className="py-6">
-      <NavigateBackBtn by="history" />
+    <Container
+      data-testid="join-set-operator-fee-page"
+      variant="vertical"
+      className="py-6"
+    >
+      <NavigateBackBtn
+        data-testid="join-set-operator-fee-back-btn"
+        by="history"
+      />
       <Form {...form}>
         <Card as="form" onSubmit={submit}>
           <CardHeader
@@ -159,6 +166,7 @@ export const SetOperatorFee: FC<ComponentPropsWithoutRef<"div">> = () => {
                 </Tooltip>
                 <FormControl>
                   <BigNumberInput
+                    data-testid="join-set-operator-fee-input"
                     displayDecimals={7}
                     id="register-operator-fee"
                     value={field.value}
@@ -210,6 +218,7 @@ export const SetOperatorFee: FC<ComponentPropsWithoutRef<"div">> = () => {
             )}
           />
           <Button
+            data-testid="join-set-operator-fee-next-btn"
             type="submit"
             size="xl"
             disabled={Boolean(form.formState.errors.yearlyFee)}

--- a/src/app/routes/maintenance.tsx
+++ b/src/app/routes/maintenance.tsx
@@ -18,6 +18,7 @@ export const Maintenance: FC = () => {
 
   return (
     <Container
+      data-testid="maintenance-page"
       variant="vertical"
       className="max-w-screen-2xl w-full p-6 items-center h-full"
     >
@@ -29,16 +30,24 @@ export const Maintenance: FC = () => {
       </div>
       <div className="flex flex-1 justify-center items-center flex-col">
         <img src="/images/maintenance.svg" alt="Maintenance" className="w-40" />
-        <Text variant="headline2" className="text-gray-700 mt-16">
+        <Text
+          data-testid="maintenance-title"
+          variant="headline2"
+          className="text-gray-700 mt-16"
+        >
           The site is currently down for maintenance
         </Text>
         <div className="flex flex-col gap-2 text-center mt-7">
-          <Text variant="body-1-medium">
+          <Text data-testid="maintenance-description" variant="body-1-medium">
             We'll be back up and running again shortly
           </Text>
-          <Text variant="body-3-medium" className="text-gray-600">
+          <Text
+            variant="body-3-medium"
+            className="text-gray-600"
+          >
             You can reach us on{" "}
             <Button
+              data-testid="maintenance-discord-link"
               variant="link"
               as="a"
               href={links.ssv.discord}

--- a/src/app/routes/not-found.tsx
+++ b/src/app/routes/not-found.tsx
@@ -7,19 +7,25 @@ import { Link } from "react-router-dom";
 export const NotFound: FC = () => {
   return (
     <Container
+      data-testid="not-found-page"
       variant="vertical"
       className="max-w-screen-2xl w-full p-6 items-center h-full"
     >
       <div className="flex flex-1 justify-center items-center flex-col">
         <img src="/images/404Robot.svg" alt="not found" className="w-40" />
-        <Text variant="headline2" className="text-gray-700 mt-16">
+        <Text
+          data-testid="not-found-title"
+          variant="headline2"
+          className="text-gray-700 mt-16"
+        >
           Page not found
         </Text>
         <div className="flex items-center flex-col gap-8 text-center mt-7">
-          <Text variant="body-2-semibold">
+          <Text data-testid="not-found-description" variant="body-2-semibold">
             The page you are looking for does not exist.
           </Text>
           <Button
+            data-testid="not-found-home-btn"
             as={Link}
             variant="secondary"
             size="xl"

--- a/src/app/routes/reshare-dkg/SignatureStep.tsx
+++ b/src/app/routes/reshare-dkg/SignatureStep.tsx
@@ -167,6 +167,7 @@ const SignatureStep = ({
                     </FormLabel>
                     <FormControl>
                       <DkgAddressInput
+                        data-testid="reshare-dkg-owner-address-input"
                         field={field}
                         isAcceptedButtonDisabled={
                           !!form.formState.errors.ownerAddress ||
@@ -210,6 +211,7 @@ const SignatureStep = ({
                     }
                   >
                     <TabsTrigger
+                      data-testid="reshare-dkg-compounding-tab"
                       value="compounding"
                       disabled={!supportsCompounding}
                       className={cn(
@@ -222,6 +224,7 @@ const SignatureStep = ({
                     </TabsTrigger>
                   </Tooltip>
                   <TabsTrigger
+                    data-testid="reshare-dkg-regular-withdrawals-tab"
                     value="regular"
                     className={cn(
                       "flex-1 h-full rounded-lg text-base font-semibold text-gray-500",
@@ -253,6 +256,7 @@ const SignatureStep = ({
                       </Text>
                       <FormControl>
                         <BigNumberInput
+                          data-testid="reshare-dkg-effective-balance-input"
                           max={MAX_EFFECTIVE_BALANCE_GWEI}
                           decimals={9}
                           displayDecimals={0}
@@ -299,6 +303,7 @@ const SignatureStep = ({
                       <FormItem>
                         <FormControl>
                           <DkgAddressInput
+                            data-testid="reshare-dkg-withdraw-address-input"
                             field={field}
                             isAcceptedButtonDisabled={
                               !!form.formState.errors.withdrawAddress ||
@@ -325,6 +330,7 @@ const SignatureStep = ({
               )}
             <div className="flex flex-row justify-between gap-1.5 w-full">
               <Button
+                data-testid="reshare-dkg-sign-btn"
                 type="submit"
                 size="xl"
                 variant={isSubmitted && isMultiSign ? "secondary" : "default"}
@@ -341,6 +347,7 @@ const SignatureStep = ({
               </Button>
               {isMultiSign && (
                 <Button
+                  data-testid="reshare-dkg-have-signatures-btn"
                   onClick={() => setIsOpenModal(true)}
                   className={"w-full"}
                   size="xl"

--- a/src/app/routes/reshare-dkg/ceremony-section.tsx
+++ b/src/app/routes/reshare-dkg/ceremony-section.tsx
@@ -172,6 +172,7 @@ const CeremonySection = ({
                     </Text>
                     <div className="flex gap-1">
                       <Button
+                        data-testid="reshare-dkg-ceremony-os-windows-btn"
                         size="sm"
                         onClick={() =>
                           (useBulkActionContext.state.dkgReshareState.selectedOs =
@@ -185,6 +186,7 @@ const CeremonySection = ({
                         Windows
                       </Button>
                       <Button
+                        data-testid="reshare-dkg-ceremony-os-mac-btn"
                         size="sm"
                         className="font-bold text-xs h-auto py-1 px-4"
                         onClick={() =>
@@ -196,6 +198,7 @@ const CeremonySection = ({
                         MacOS
                       </Button>
                       <Button
+                        data-testid="reshare-dkg-ceremony-os-linux-btn"
                         size="sm"
                         className="font-bold text-xs h-auto py-1 px-4"
                         onClick={() =>
@@ -215,6 +218,7 @@ const CeremonySection = ({
                       {cmd.isLoading ? <Spinner /> : cmd.data}
                     </Text>
                     <Button
+                      data-testid="reshare-dkg-ceremony-copy-cmd-btn"
                       size="sm"
                       className="h-8"
                       variant={copyState.value ? "success" : "secondary"}
@@ -258,7 +262,12 @@ const CeremonySection = ({
         }
       />
       {isEnabled && (
-        <Button size="xl" disabled={!copyState.value} onClick={nextStep}>
+        <Button
+          data-testid="reshare-dkg-ceremony-initiated-btn"
+          size="xl"
+          disabled={!copyState.value}
+          onClick={nextStep}
+        >
           DKG Ceremony Initiated
         </Button>
       )}

--- a/src/app/routes/reshare-dkg/dkg-address-input.tsx
+++ b/src/app/routes/reshare-dkg/dkg-address-input.tsx
@@ -10,6 +10,7 @@ export const DkgAddressInput = ({
   setIsInputDisabled,
   isAcceptedButtonDisabled,
   acceptedButtonLabel,
+  "data-testid": testId,
 }: {
   field: ControllerRenderProps<
     {
@@ -25,8 +26,10 @@ export const DkgAddressInput = ({
   value: string;
   acceptedButtonLabel?: string;
   setIsInputDisabled: (isDisabled: boolean) => void;
+  "data-testid"?: string;
 }) => (
   <Input
+    data-testid={testId}
     {...field}
     disabled={isInputDisabled}
     value={value}
@@ -34,6 +37,7 @@ export const DkgAddressInput = ({
     rightSlot={
       acceptedButtonLabel && (
         <Button
+          data-testid={testId ? `${testId}-accept-btn` : undefined}
           size="sm"
           className="border-none text-primary-500 hover:bg-transparent hover:text-primary-500"
           variant={isInputDisabled ? "outline" : "secondary"}

--- a/src/app/routes/reshare-dkg/remove-validators-section.tsx
+++ b/src/app/routes/reshare-dkg/remove-validators-section.tsx
@@ -60,11 +60,20 @@ const RemoveValidatorsSection = ({
             className={"w-full"}
             target="_blank"
           >
-            <Button size="xl" className={"w-full"} variant={"secondary"}>
+            <Button
+              data-testid="reshare-dkg-remove-validators-link-btn"
+              size="xl"
+              className={"w-full"}
+              variant={"secondary"}
+            >
               Remove Selected Validators <FaExternalLinkAlt />
             </Button>
           </a>
-          <Button size="xl" onClick={nextStep}>
+          <Button
+            data-testid="reshare-dkg-remove-validators-confirm-btn"
+            size="xl"
+            onClick={nextStep}
+          >
             My Validator Has Been Removed
           </Button>
         </div>

--- a/src/app/routes/reshare-dkg/reshare-dkg.tsx
+++ b/src/app/routes/reshare-dkg/reshare-dkg.tsx
@@ -147,6 +147,7 @@ const ReshareDkg = () => {
 
   return (
     <Container
+      data-testid="reshare-dkg-page"
       variant="vertical"
       size="lg"
       className="py-5"
@@ -205,6 +206,7 @@ const ReshareDkg = () => {
         validators={reshareContext.proofsQuery.data?.validators || []}
       />
       <Card
+        data-testid="reshare-dkg-step-4-card"
         className={`border ${currentStep === ReshareSteps.Register ? "border-primary-500" : ""} w-full`}
       >
         <CardHeader
@@ -218,6 +220,7 @@ const ReshareDkg = () => {
         />
         {currentStep === ReshareSteps.Register && (
           <Button
+            data-testid="reshare-dkg-step-4-register-btn"
             size="xl"
             as={Link}
             to={
@@ -264,13 +267,17 @@ const ReshareDkg = () => {
                     render={({ field }) => (
                       <FormItem>
                         <FormControl>
-                          <Input {...field} />
+                          <Input
+                            data-testid="reshare-dkg-signature-modal-input"
+                            {...field}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
                     )}
                   />
                   <Button
+                    data-testid="reshare-dkg-signature-modal-submit-btn"
                     type="submit"
                     size="xl"
                     className={"w-full"}

--- a/src/app/routes/reshare-dkg/reshare.tsx
+++ b/src/app/routes/reshare-dkg/reshare.tsx
@@ -56,6 +56,7 @@ const Reshare = () => {
     <ReshareDkg />
   ) : (
     <Container
+      data-testid="reshare-unhealthy-operators-page"
       size="lg"
       variant="vertical"
       className="py-6"
@@ -63,7 +64,10 @@ const Reshare = () => {
       navigateRoutePath={`/clusters/${clusterHash}/reshare/select-operators`}
     >
       <Card className="w-full">
-        <Text variant="headline4">
+        <Text
+          data-testid="reshare-unhealthy-operators-title"
+          variant="headline4"
+        >
           Pick the cluster of network operators to run your validator
         </Text>
         <UnhealthyOperatorsList
@@ -73,6 +77,7 @@ const Reshare = () => {
         />
 
         <Button
+          data-testid="reshare-unhealthy-operators-change-btn"
           as={Link}
           to="../select-operators?has_dkg_address=true"
           size="xl"

--- a/src/app/routes/reshare-dkg/upload-proofs.tsx
+++ b/src/app/routes/reshare-dkg/upload-proofs.tsx
@@ -52,6 +52,7 @@ const UploadProofs = () => {
   }, [proofsQuery.isLoading, proofsQuery.isSuccess]);
   return (
     <Container
+      data-testid="reshare-upload-proofs-page"
       variant="vertical"
       size="lg"
       className="p-6 font-medium w-[1096px]"
@@ -143,7 +144,12 @@ const UploadProofs = () => {
                   ))}
                 </div>
               </div>
-              <Button onClick={nextStep}>Next</Button>
+              <Button
+                data-testid="reshare-upload-proofs-next-btn"
+                onClick={nextStep}
+              >
+                Next
+              </Button>
             </div>
           )}
         </Card>

--- a/src/components/banners/eth-fees-banner.tsx
+++ b/src/components/banners/eth-fees-banner.tsx
@@ -18,13 +18,21 @@ export const EthFeesBanner: FC = () => {
   };
 
   return (
-    <div className="bg-orange-400 flex items-center justify-center px-5 py-4 relative w-full">
+    <div
+      data-testid="eth-fees-banner"
+      className="bg-orange-400 flex items-center justify-center px-5 py-4 relative w-full"
+    >
       <div className="flex-1 flex items-center justify-center">
-        <Text variant="body-2-medium" className="text-white text-center">
-          ETH fees are now active. A default ETH fee has been applied to your operators. You may update this fee at any time in your dashboard. <Link className={"text-[#7F35BA] underline"} target={"_blank"} to={'http://docs.ssv.network/operators/operator-onboarding/'}>Read more.</Link>
+        <Text
+          data-testid="eth-fees-banner-message"
+          variant="body-2-medium"
+          className="text-white text-center"
+        >
+          ETH fees are now active. A default ETH fee has been applied to your operators. You may update this fee at any time in your dashboard. <Link data-testid="eth-fees-banner-read-more-link" className={"text-[#7F35BA] underline"} target={"_blank"} to={'http://docs.ssv.network/operators/operator-onboarding/'}>Read more.</Link>
         </Text>
       </div>
       <button
+        data-testid="eth-fees-banner-dismiss-btn"
         onClick={handleDismiss}
         className="absolute right-5 top-1/2 -translate-y-1/2 text-white hover:opacity-80 transition-opacity"
         aria-label="Dismiss banner"

--- a/src/components/banners/eth-funding-migration-banner.tsx
+++ b/src/components/banners/eth-funding-migration-banner.tsx
@@ -18,13 +18,21 @@ export const EthFundingMigrationBanner: FC = () => {
   };
 
   return (
-    <div className="bg-orange-400 flex items-center justify-center px-5 py-4 relative w-full">
+    <div
+      data-testid="eth-funding-migration-banner"
+      className="bg-orange-400 flex items-center justify-center px-5 py-4 relative w-full"
+    >
       <div className="flex-1 flex items-center justify-center">
-        <Text variant="body-2-medium" className="text-white text-center">
-          ETH fees are now active. Switch to ETH to regain full cluster management capabilities. <Link className={"text-[#7F35BA] underline"} target={"_blank"} to={'http://docs.ssv.network/stakers/cluster-management/migrating-to-eth-clusters'}>Read more.</Link>
+        <Text
+          data-testid="eth-funding-migration-banner-message"
+          variant="body-2-medium"
+          className="text-white text-center"
+        >
+          ETH fees are now active. Switch to ETH to regain full cluster management capabilities. <Link data-testid="eth-funding-migration-banner-read-more-link" className={"text-[#7F35BA] underline"} target={"_blank"} to={'http://docs.ssv.network/stakers/cluster-management/migrating-to-eth-clusters'}>Read more.</Link>
         </Text>
       </div>
       <button
+        data-testid="eth-funding-migration-banner-dismiss-btn"
         onClick={handleDismiss}
         className="absolute right-5 top-1/2 -translate-y-1/2 text-white hover:opacity-80 transition-opacity"
         aria-label="Dismiss banner"

--- a/src/components/dashboard/dashboard-picker.tsx
+++ b/src/components/dashboard/dashboard-picker.tsx
@@ -19,9 +19,13 @@ export const DashboardPicker: DashboardPickerFC = ({ ...props }) => {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger>
+      <DropdownMenuTrigger data-testid="dashboard-picker-trigger">
         <div className="flex items-center gap-2">
-          <Text variant="headline3" {...props}>
+          <Text
+            data-testid="dashboard-picker-label"
+            variant="headline3"
+            {...props}
+          >
             {isOperators
               ? "Operators"
               : isValidators
@@ -33,10 +37,20 @@ export const DashboardPicker: DashboardPickerFC = ({ ...props }) => {
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         <DropdownMenuItem asChild defaultChecked={isValidators} className="">
-          <Link to="/clusters">Validator Clusters</Link>
+          <Link
+            data-testid="dashboard-picker-item-clusters"
+            to="/clusters"
+          >
+            Validator Clusters
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild defaultChecked={isOperators}>
-          <Link to="/operators">Operators</Link>
+          <Link
+            data-testid="dashboard-picker-item-operators"
+            to="/operators"
+          >
+            Operators
+          </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/modals/batch-transaction-modal.tsx
+++ b/src/components/modals/batch-transaction-modal.tsx
@@ -55,9 +55,13 @@ export const BatchTransactionModal: FC<BatchTransactionModalProps> = () => {
 
   return (
     <Dialog isOpen={state.value !== "idle"}>
-      <DialogContent className="max-w-[520px] gap-5">
+      <DialogContent
+        data-testid="batch-transaction-modal"
+        className="max-w-[520px] gap-5"
+      >
         <DialogHeader className="flex-row items-center justify-between">
           <DialogTitle
+            data-testid="batch-transaction-modal-title"
             className={textVariants({
               variant: "body-1-bold",
               className: "text-gray-800",
@@ -67,6 +71,7 @@ export const BatchTransactionModal: FC<BatchTransactionModalProps> = () => {
           </DialogTitle>
           {state.matches("failed") && (
             <DialogClose
+              data-testid="batch-transaction-modal-close-btn"
               className="text-gray-900"
               onClick={() => send({ type: "cancel" })}
             >
@@ -136,6 +141,7 @@ export const BatchTransactionModal: FC<BatchTransactionModalProps> = () => {
         <DialogFooter className="block">
           <Collapse isOpened={state.matches("failed")}>
             <Button
+              data-testid="batch-transaction-modal-retry-btn"
               size="lg"
               className="w-full"
               variant="default"

--- a/src/components/operator/operators-table/operator-table-row.tsx
+++ b/src/components/operator/operators-table/operator-table-row.tsx
@@ -10,6 +10,7 @@ import { useOperatorEarningsAndFees } from "@/hooks/operator/use-operator-earnin
 
 export type OperatorTableRowProps = {
   operator: Operator;
+  rowIndex?: number;
 };
 
 type FCProps = FC<
@@ -19,6 +20,7 @@ type FCProps = FC<
 
 export const OperatorTableRow: FCProps = ({
   operator: _operator,
+  rowIndex,
   className,
   ...props
 }) => {
@@ -31,19 +33,25 @@ export const OperatorTableRow: FCProps = ({
   return (
     <TableRow
       key={operator.id}
+      data-testid="dashboard-operators-table-row"
+      data-testid-index={rowIndex}
+      data-testid-entity={operator.id}
       className={cn("cursor-pointer max-h-7", className)}
       {...props}
     >
-      <TableCell className="font-medium">
+      <TableCell
+        data-testid="dashboard-operators-table-row-name"
+        className="font-medium"
+      >
         <OperatorDetails operator={operator} />
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-status">
         <OperatorStatusBadge size="sm" status={operator.status} />
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-performance">
         {percentageFormatter.format(operator.performance["30d"])}
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-balance">
         <div className="flex items-center gap-2 w-max">
           <div className="flex items-center gap-1 text-gray-800 font-medium">
             <img
@@ -51,7 +59,9 @@ export const OperatorTableRow: FCProps = ({
               src="/images/networks/dark.svg"
               className="size-5"
             />{" "}
-            <span>{formatETH(balanceEth)}</span>
+            <span data-testid="dashboard-operators-table-row-balance-eth">
+              {formatETH(balanceEth)}
+            </span>
           </div>
           {balanceSSV > 0 && (
             <div className="flex items-center gap-1 text-gray-800 font-medium">
@@ -61,12 +71,14 @@ export const OperatorTableRow: FCProps = ({
                 src="/images/ssvIcons/icon.svg"
                 className="size-5"
               />{" "}
-              {formatSSV(balanceSSV)}
+              <span data-testid="dashboard-operators-table-row-balance-ssv">
+                {formatSSV(balanceSSV)}
+              </span>
             </div>
           )}
         </div>
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-yearly-fee">
         <div className="flex items-center gap-2 w-max">
           <div className="flex items-center gap-1 text-gray-800 font-medium">
             <img
@@ -74,7 +86,9 @@ export const OperatorTableRow: FCProps = ({
               src="/images/networks/dark.svg"
               className="size-5"
             />{" "}
-            {formatETH(yearlyFeeEth)}
+            <span data-testid="dashboard-operators-table-row-yearly-fee-eth">
+              {formatETH(yearlyFeeEth)}
+            </span>
           </div>
           {yearlyFeeSSV > 0 && (
             <div className="flex items-center gap-1 text-gray-800 font-medium">
@@ -84,13 +98,17 @@ export const OperatorTableRow: FCProps = ({
                 src="/images/ssvIcons/icon.svg"
                 className="size-5"
               />{" "}
-              {formatSSV(yearlyFeeSSV)}
+              <span data-testid="dashboard-operators-table-row-yearly-fee-ssv">
+                {formatSSV(yearlyFeeSSV)}
+              </span>
             </div>
           )}
         </div>
       </TableCell>
-      <TableCell>{operator.validators_count}</TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-validators-count">
+        {operator.validators_count}
+      </TableCell>
+      <TableCell data-testid="dashboard-operators-table-row-effective-balance">
         <div className="flex items-center gap-2">
           <div className="flex items-center gap-1 text-gray-800 font-medium">
             <img

--- a/src/components/operator/operators-table/operators-table.tsx
+++ b/src/components/operator/operators-table/operators-table.tsx
@@ -78,22 +78,48 @@ export const OperatorsTable: FCProps = ({
     );
   };
   return (
-    <div className="flex flex-col w-full">
+    <div
+      data-testid="dashboard-operators-table"
+      className="flex flex-col w-full"
+    >
       <Table
         className={cn(className, "w-full rounded-t-xl overflow-hidden")}
         {...props}
       >
         <TableHeader>
-          <TableHead>Operator name</TableHead>
-          <TableHead>Status</TableHead>
-          <TableHead>{renderSortableHeader({ type: "performance30d", title: "30D Performance" })}</TableHead>
-          <TableHead>Balance (ETH | SSV)</TableHead>
-          <TableHead>Yearly Fee (ETH | SSV)</TableHead>
-          <TableHead>{renderSortableHeader({ type: "validatorsCount", title: "Validators" })}</TableHead>
-          <TableHead>{renderSortableHeader({ type: "effectiveBalance", title: "Total ETH Managed" })}</TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-name">
+            Operator name
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-status">
+            Status
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-performance">
+            {renderSortableHeader({
+              type: "performance30d",
+              title: "30D Performance",
+            })}
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-balance">
+            Balance (ETH | SSV)
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-yearly-fee">
+            Yearly Fee (ETH | SSV)
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-validators">
+            {renderSortableHeader({
+              type: "validatorsCount",
+              title: "Validators",
+            })}
+          </TableHead>
+          <TableHead data-testid="dashboard-operators-table-header-effective-balance">
+            {renderSortableHeader({
+              type: "effectiveBalance",
+              title: "Total ETH Managed",
+            })}
+          </TableHead>
         </TableHeader>
         <TableBody>
-          {operators.map((operator) => {
+          {operators.map((operator, index) => {
             const { queryKey } = getOperatorQueryOptions(operator.id);
             const cachedOperator = queryClient.getQueryData(queryKey);
             if (cachedOperator?.is_deleted) return null;
@@ -102,6 +128,7 @@ export const OperatorsTable: FCProps = ({
               <OperatorTableRow
                 key={operator.id}
                 operator={operator}
+                rowIndex={index}
                 onClick={() => {
                   return onOperatorClick(operator);
                 }}

--- a/src/components/ui/cluster-back-btn-header.tsx
+++ b/src/components/ui/cluster-back-btn-header.tsx
@@ -7,12 +7,16 @@ export const ClusterBackBtnHeader = () => {
   const { clusterHash } = useClusterPageParams();
 
   return (
-    <div className="flex gap-4">
+    <div data-testid="cluster-back-btn-header" className="flex gap-4">
       Cluster {shortenAddress((clusterHash || "").slice(2) || "", 4, 4)}
       <div className="h-6 w-[1px] bg-gray-400" />
-      <Text className="text-gray-700 font-medium flex items-center gap-4">
+      <Text
+        data-testid="cluster-back-btn-header-cluster-hash"
+        className="text-gray-700 font-medium flex items-center gap-4"
+      >
         {shortenAddress((clusterHash || "").slice(2) || "", 4, 4)}
         <CopyBtn
+          data-testid="cluster-back-btn-header-copy-cluster-hash-btn"
           isFullSizeIcon
           text={clusterHash}
           className="bg-transparent text-[24px] size-[24px] p-0"

--- a/src/components/ui/expand-button.tsx
+++ b/src/components/ui/expand-button.tsx
@@ -5,12 +5,15 @@ import { IconButton } from "@/components/ui/button.tsx";
 const ExpandButton = ({
   setIsOpen,
   isOpen,
+  "data-testid": testId,
 }: {
   setIsOpen: (isOpen: boolean) => void;
   isOpen: boolean;
+  "data-testid"?: string;
 }) => {
   return (
     <IconButton
+      data-testid={testId}
       variant="ghost"
       className="size-9 p-[2px] hover:bg-primary-100 hover:text-primary-500"
       onClick={(ev) => {

--- a/src/components/ui/file-upload.tsx
+++ b/src/components/ui/file-upload.tsx
@@ -307,6 +307,7 @@ export const FileUploaderItem = forwardRef<
       </div>
       <button
         type="button"
+        data-testid={`file-uploader-item-${index}-remove-btn`}
         className={cn(
           "absolute",
           direction === "rtl" ? "top-1 left-1" : "top-1 right-1",
@@ -399,7 +400,10 @@ export const JSONFileUploader = ({
       value={files}
       onValueChange={onValueChange}
     >
-      <FileInput className="h-64 flex flex-col items-center justify-center bg-gray-100 border border-gray-300 rounded-xl">
+      <FileInput
+        data-testid="json-file-uploader-dropzone"
+        className="h-64 flex flex-col items-center justify-center bg-gray-100 border border-gray-300 rounded-xl"
+      >
         <div className="flex flex-col items-center gap-4">
           {isLoading ? (
             <div className="size-12">
@@ -414,11 +418,19 @@ export const JSONFileUploader = ({
             />
           )}
           {isLoading && loadingText ? (
-            <Text variant="body-2-medium" className="text-gray-500">
+            <Text
+              data-testid="json-file-uploader-loading"
+              variant="body-2-medium"
+              className="text-gray-500"
+            >
               {loadingText}
             </Text>
           ) : !files.length ? (
-            <Text variant="body-2-medium" className="text-gray-500">
+            <Text
+              data-testid="json-file-uploader-empty-prompt"
+              variant="body-2-medium"
+              className="text-gray-500"
+            >
               Drag and drop files or{" "}
               <Span className="text-primary-500">browse</Span>
             </Text>
@@ -426,6 +438,7 @@ export const JSONFileUploader = ({
             <>
               {isError && error ? (
                 <Text
+                  data-testid="json-file-uploader-error"
                   variant="body-2-medium"
                   className="text-red-500 text-center max-w-96"
                 >
@@ -437,6 +450,7 @@ export const JSONFileUploader = ({
                     files.length > 0 &&
                     files.map((file, i) => (
                       <Text
+                        data-testid={`json-file-uploader-file-${i}-name`}
                         variant="body-2-medium"
                         className={cn("text-success-500", {
                           "text-error-500": isError,
@@ -451,6 +465,7 @@ export const JSONFileUploader = ({
               )}
 
               <Button
+                data-testid="json-file-uploader-remove-btn"
                 variant="link"
                 onClick={(ev) => {
                   ev.preventDefault();

--- a/src/components/ui/multisig-transaction-modal.tsx
+++ b/src/components/ui/multisig-transaction-modal.tsx
@@ -35,12 +35,18 @@ export const MultisigTransactionModal: FCProps = () => {
       };
   return (
     <Dialog isOpen={isOpen}>
-      <DialogContent className="flex bg-gray-50 flex-col gap-8 max-w-[424px] font-medium ">
+      <DialogContent
+        data-testid="multisig-transaction-modal"
+        className="flex bg-gray-50 flex-col gap-8 max-w-[424px] font-medium "
+      >
         <div className="flex flex-col gap-3">
-          <DialogTitle>
+          <DialogTitle data-testid="multisig-transaction-modal-title">
             <Text variant="headline4">Transaction Initiated</Text>
           </DialogTitle>
-          <Text variant="body-2-medium">
+          <Text
+            data-testid="multisig-transaction-modal-description"
+            variant="body-2-medium"
+          >
             Your transaction has been successfully initiated within the
             multi-sig wallet and is now pending approval from other
             participants.
@@ -50,7 +56,12 @@ export const MultisigTransactionModal: FCProps = () => {
           </Text>
         </div>
         <img src="/images/ssv-loader.svg" className="size-28 mx-auto" />
-        <Button {...(buttonProps as ButtonProps)}>Close</Button>
+        <Button
+          data-testid="multisig-transaction-modal-close-btn"
+          {...(buttonProps as ButtonProps)}
+        >
+          Close
+        </Button>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -15,6 +15,7 @@ const PaginationContainer = ({
   <nav
     role="navigation"
     aria-label="pagination"
+    data-testid="pagination-nav"
     className={cn("mx-auto flex w-full justify-center", className)}
     {...props}
   />
@@ -72,7 +73,11 @@ PaginationLink.displayName = "PaginationLink";
 const PaginationPrevious = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink aria-label="Go to previous page" {...props}>
+  <PaginationLink
+    aria-label="Go to previous page"
+    data-testid="pagination-prev-btn"
+    {...props}
+  >
     <ChevronLeft className="size-4" />
   </PaginationLink>
 );
@@ -81,7 +86,11 @@ PaginationPrevious.displayName = "PaginationPrevious";
 const PaginationNext = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink aria-label="Go to next page" {...props}>
+  <PaginationLink
+    aria-label="Go to next page"
+    data-testid="pagination-next-btn"
+    {...props}
+  >
     <ChevronRight className="size-4" />
   </PaginationLink>
 );
@@ -93,6 +102,7 @@ const PaginationEllipsis = ({
 }: React.ComponentProps<"span">) => (
   <span
     aria-hidden
+    data-testid="pagination-ellipsis"
     className={cn("flex h-9 w-9 items-center justify-center", className)}
     {...props}
   >
@@ -132,6 +142,7 @@ const Pagination: React.FC<React.ComponentProps<"nav"> & PaginationProps> = ({
             <PaginationLink
               to={{ search: buildSearch(i + 1) }}
               isActive={i + 1 === pagination.page}
+              data-testid={`pagination-page-${i + 1}-btn`}
             >
               {i + 1}
             </PaginationLink>

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -46,6 +46,7 @@ const Toast = React.forwardRef<
   return (
     <ToastPrimitives.Root
       ref={ref}
+      data-testid="toast"
       className={cn(toastVariants({ variant }), className)}
       {...props}
     />
@@ -74,6 +75,7 @@ const ToastClose = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Close
     ref={ref}
+    data-testid="toast-close-btn"
     className={cn(
       "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className,
@@ -92,6 +94,7 @@ const ToastTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Title
     ref={ref}
+    data-testid="toast-title"
     className={cn("text-sm font-semibold", className)}
     {...props}
   />
@@ -104,6 +107,7 @@ const ToastDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Description
     ref={ref}
+    data-testid="toast-description"
     className={cn("text-sm opacity-90 break-words", className)}
     style={{
       wordBreak: "break-word",

--- a/src/components/ui/transaction-modal.tsx
+++ b/src/components/ui/transaction-modal.tsx
@@ -37,17 +37,28 @@ export const TransactionModal: FCProps = () => {
 
   return (
     <Dialog isOpen={isOpen}>
-      <DialogContent className="flex bg-gray-50 flex-col gap-8 max-w-[424px] font-medium ">
+      <DialogContent
+        data-testid="transaction-modal"
+        className="flex bg-gray-50 flex-col gap-8 max-w-[424px] font-medium "
+      >
         <div className="flex flex-col gap-3">
-          <DialogTitle>
+          <DialogTitle data-testid="transaction-modal-title">
             <Text variant="headline4">Sending Transaction</Text>
           </DialogTitle>
-          <Text variant="body-2-medium">{description}</Text>
+          <Text
+            data-testid="transaction-modal-description"
+            variant="body-2-medium"
+          >
+            {description}
+          </Text>
         </div>
         <img src={loaderSrc} className="size-28 mx-auto" />
         {isTwoStep && (
           <div className="flex  w-[244px] mx-auto">
-            <div className="flex flex-col items-center gap-1">
+            <div
+              data-testid="transaction-modal-pending-step"
+              className="flex flex-col items-center gap-1"
+            >
               <StepperDot
                 className=""
                 disabled={isIndexing}
@@ -64,7 +75,10 @@ export const TransactionModal: FCProps = () => {
               </Text>
             </div>
             <Divider className="flex-1 mt-3" />
-            <div className="flex flex-col items-center gap-1">
+            <div
+              data-testid="transaction-modal-indexing-step"
+              className="flex flex-col items-center gap-1"
+            >
               <StepperDot
                 disabled={isPending}
                 variant={isPending || isIndexing ? "active" : "done"}
@@ -91,15 +105,21 @@ export const TransactionModal: FCProps = () => {
             </Text>
             <div className="flex items-center h-[50px] px-5 pr-2 py-3 border border-gray-300 rounded-xl">
               <Text
+                data-testid="transaction-modal-tx-hash"
                 variant="body-2-medium"
                 className="flex-1 text-ellipsis overflow-hidden mr-3"
               >
                 {meta.hash}
               </Text>
-              <CopyBtn text={meta.hash} className="size-8" />
+              <CopyBtn
+                data-testid="transaction-modal-copy-tx-hash-btn"
+                text={meta.hash}
+                className="size-8"
+              />
             </div>
           </div>
           <Button
+            data-testid="transaction-modal-view-tx-link"
             as="a"
             target="_blank"
             variant="link"

--- a/src/components/validator/clusters-table/clusters-table-row.tsx
+++ b/src/components/validator/clusters-table/clusters-table-row.tsx
@@ -24,6 +24,7 @@ import { Link, useLocation } from "react-router-dom";
 
 export type ClustersTableRowProps = {
   cluster: Cluster;
+  rowIndex?: number;
 };
 
 type FCProps = FC<
@@ -31,7 +32,12 @@ type FCProps = FC<
     ClustersTableRowProps
 >;
 
-export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
+export const ClustersTableRow: FCProps = ({
+  cluster,
+  rowIndex,
+  className,
+  ...props
+}) => {
   const location = useLocation();
   const from = `${location.pathname}${location.search}${location.hash}`;
 
@@ -53,18 +59,21 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
   return (
     <TableRow
       key={cluster.id}
+      data-testid="dashboard-clusters-table-row"
+      data-testid-index={rowIndex}
+      data-testid-entity={cluster.clusterId}
       className={cn("cursor-pointer", className, {
         "bg-warning-200": runway.data?.isAtRisk,
         "bg-error-50": isLiquidated,
       })}
       {...props}
     >
-      <TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-name">
         <div className="max-w-[88px] truncate">
           {resolvedCluster.name || shortenClusterId(cluster.clusterId)}
         </div>
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-operators">
         <div className="flex gap-[2px]">
           {cluster.operators.map((o) => {
             const Cmp: FC = () => {
@@ -100,14 +109,16 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
           })}
         </div>
       </TableCell>
-      <TableCell>{resolvedCluster.validatorCount}</TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-validators-count">
+        {resolvedCluster.validatorCount}
+      </TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-effective-balance">
         <div className="flex items-center gap-1 text-gray-800 font-medium">
           <img src="/images/networks/dark.svg" className="size-5" />{" "}
           {formatEffectiveBalance(BigInt(effectiveBalance))}
         </div>
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-balance">
         {isSsvCluster ? (
           <div className="flex items-center gap-1 text-gray-800 font-medium">
             <img src="/images/ssvIcons/icon.svg" className="size-5" />{" "}
@@ -120,7 +131,7 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
           </div>
         )}
       </TableCell>
-      <TableCell>
+      <TableCell data-testid="dashboard-clusters-table-row-runway">
         {isLoadingRunway ? (
           <Skeleton className="h-5 w-14" />
         ) : resolvedCluster.validatorCount > 0 ? (
@@ -129,15 +140,26 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
           "-"
         )}
       </TableCell>
-      <TableCell className="whitespace-nowrap">
+      <TableCell
+        data-testid="dashboard-clusters-table-row-status"
+        className="whitespace-nowrap"
+      >
         {isLiquidated ? (
-          <Badge size="sm" variant="error">
+          <Badge
+            data-testid="dashboard-clusters-table-row-liquidated-badge"
+            size="sm"
+            variant="error"
+          >
             Liquidated
           </Badge>
         ) : isLoadingRunway ? null : (
           <>
             {runway.data?.isAtRisk && (
-              <Badge size="sm" variant="warning">
+              <Badge
+                data-testid="dashboard-clusters-table-row-low-runway-badge"
+                size="sm"
+                variant="warning"
+              >
                 Low runway
               </Badge>
             )}
@@ -147,6 +169,7 @@ export const ClustersTableRow: FCProps = ({ cluster, className, ...props }) => {
       <TableCell>
         {isSsvCluster && (
           <Button
+            data-testid="dashboard-clusters-table-row-switch-to-eth-btn"
             as={Link}
             to={`/switch-wizard/${cluster.clusterId}`}
             state={{ from }}

--- a/src/components/validator/clusters-table/clusters-table.tsx
+++ b/src/components/validator/clusters-table/clusters-table.tsx
@@ -101,13 +101,13 @@ export const ClusterTable: FCProps = ({
   };
 
   return (
-    <div className="flex flex-col w-full">
+    <div data-testid="dashboard-clusters-table" className="flex flex-col w-full">
       <Table
         className={cn(className, "w-full rounded-t-xl overflow-hidden")}
         {...props}
       >
         <TableHeader>
-          <TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-cluster">
             <Tooltip
               asChild
               content={
@@ -115,6 +115,7 @@ export const ClusterTable: FCProps = ({
                   Clusters represent a unique set of operators who operate your
                   validators and can be represented by ID or a name.{" "}
                   <Button
+                    data-testid="dashboard-clusters-table-header-cluster-more-link"
                     as={Link}
                     to={links.MORE_ON_CLUSTERS}
                     target="_blank"
@@ -136,30 +137,37 @@ export const ClusterTable: FCProps = ({
               })}
             </Tooltip>
           </TableHead>
-          <TableHead>Operators</TableHead>
-          <TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-operators">
+            Operators
+          </TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-validators">
             {renderSortableHeader({
               type: "validatorCount",
               title: "Validators",
             })}
           </TableHead>
-          <TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-effective-balance">
             {renderSortableHeader({
               type: "effectiveBalance",
               title: "Total Effective Balance",
             })}
           </TableHead>
-          <TableHead>Cluster Balance</TableHead>
-          <TableHead>Operational Runway</TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-cluster-balance">
+            Cluster Balance
+          </TableHead>
+          <TableHead data-testid="dashboard-clusters-table-header-operational-runway">
+            Operational Runway
+          </TableHead>
           <TableHead />
           <TableHead />
         </TableHeader>
         <TableBody>
-          {clusters.map((cluster) => {
+          {clusters.map((cluster, index) => {
             return (
               <ClustersTableRow
                 key={cluster.id}
                 cluster={cluster}
+                rowIndex={index}
                 onClick={() => onClusterClick(cluster)}
               />
             );
@@ -169,13 +177,20 @@ export const ClusterTable: FCProps = ({
 
       <div className="bg-gray-50 w-full">{isLoading && <Loading />}</div>
       {isEmpty ? (
-        <div className="flex flex-col items-center justify-center gap-4 w-full bg-gray-50 py-16 rounded-b-2xl">
+        <div
+          data-testid="dashboard-clusters-empty-state"
+          className="flex flex-col items-center justify-center gap-4 w-full bg-gray-50 py-16 rounded-b-2xl"
+        >
           <LogoIcon className="size-20" />
           <div className="flex flex-col items-center gap-2">
-            <Text variant="body-2-medium">
+            <Text
+              data-testid="dashboard-clusters-empty-message"
+              variant="body-2-medium"
+            >
               You don't have any clusters yet.
             </Text>
             <Button
+              data-testid="dashboard-clusters-empty-create-btn"
               as={Link}
               to="/join/validator"
               size="lg"

--- a/src/components/wizard/switch-wizard-step-four.tsx
+++ b/src/components/wizard/switch-wizard-step-four.tsx
@@ -22,7 +22,11 @@ export const SwitchWizardStepFour: FC<SwitchWizardStepFourProps> = ({
   clusterPath,
 }) => {
   return (
-    <Container variant="vertical" className="py-6">
+    <Container
+      data-testid="switch-wizard-step-four-page"
+      variant="vertical"
+      className="py-6"
+    >
       <Card
         variant="unstyled"
         className="relative w-full overflow-hidden rounded-2xl bg-white p-8"
@@ -35,7 +39,10 @@ export const SwitchWizardStepFour: FC<SwitchWizardStepFourProps> = ({
 
         <div className="relative z-10 flex flex-col gap-6">
           <div className="flex flex-col gap-4 items-start">
-            <Text variant="headline4">
+            <Text
+              data-testid="switch-wizard-step-four-title"
+              variant="headline4"
+            >
               Cluster Successfully Migrated to ETH Fees
             </Text>
             <Text variant="body-2-medium" className="text-gray-700">
@@ -103,6 +110,7 @@ export const SwitchWizardStepFour: FC<SwitchWizardStepFourProps> = ({
 
           {clusterPath ? (
             <Button
+              data-testid="switch-wizard-step-four-manage-cluster-btn"
               as={Link}
               to={clusterPath}
               size="xl"
@@ -112,7 +120,13 @@ export const SwitchWizardStepFour: FC<SwitchWizardStepFourProps> = ({
               Manage Cluster
             </Button>
           ) : (
-            <Button size="xl" width="full" className="font-semibold" disabled>
+            <Button
+              data-testid="switch-wizard-step-four-manage-cluster-btn-disabled"
+              size="xl"
+              width="full"
+              className="font-semibold"
+              disabled
+            >
               Manage Cluster
             </Button>
           )}

--- a/src/components/wizard/switch-wizard-step-one.tsx
+++ b/src/components/wizard/switch-wizard-step-one.tsx
@@ -23,6 +23,7 @@ export const SwitchWizardStepOne = ({
 }: SwitchWizardStepOneProps) => {
   return (
     <Container
+      data-testid="switch-wizard-step-one-page"
       variant="vertical"
       className="py-6"
       backButtonLabel={backButtonLabel}
@@ -34,7 +35,12 @@ export const SwitchWizardStepOne = ({
         className="w-full flex flex-col gap-5 p-8 bg-white rounded-2xl"
       >
         <div className="flex flex-col gap-4 items-start">
-          <Text variant="headline4">Switch Cluster to ETH Fees</Text>
+          <Text
+            data-testid="switch-wizard-step-one-title"
+            variant="headline4"
+          >
+            Switch Cluster to ETH Fees
+          </Text>
           <Text variant="body-2-medium" className="text-gray-700 leading-6">
             You are about to migrate your cluster from SSV-denominated payments
             to ETH-based operator and network fees.
@@ -47,7 +53,10 @@ export const SwitchWizardStepOne = ({
         </div>
 
         <Alert variant="warning" className="flex gap-3 items-center px-4 py-3">
-          <AlertDescription className="text-sm font-medium text-gray-800">
+          <AlertDescription
+            data-testid="switch-wizard-step-one-warning"
+            className="text-sm font-medium text-gray-800"
+          >
             Once you switch, this change is permanent and cannot be reversed.
           </AlertDescription>
         </Alert>
@@ -55,6 +64,7 @@ export const SwitchWizardStepOne = ({
         <OperatorFeeComparison operators={operators} />
 
         <Button
+          data-testid="switch-wizard-step-one-next-btn"
           variant="default"
           size="lg"
           width="full"

--- a/src/components/wizard/switch-wizard-step-three.tsx
+++ b/src/components/wizard/switch-wizard-step-three.tsx
@@ -71,6 +71,7 @@ export const SwitchWizardStepThree = ({
 
   return (
     <Container
+      data-testid="switch-wizard-step-three-page"
       variant="vertical"
       className="py-6"
       backButtonLabel={backButtonLabel}
@@ -83,7 +84,12 @@ export const SwitchWizardStepThree = ({
         className="w-full flex flex-col gap-5 p-8 bg-white rounded-2xl"
       >
         <div className="flex justify-between w-full">
-          <Text variant="headline4">Transaction Details</Text>
+          <Text
+            data-testid="switch-wizard-step-three-title"
+            variant="headline4"
+          >
+            Transaction Details
+          </Text>
         </div>
 
         <div className="space-y-2">
@@ -211,6 +217,7 @@ export const SwitchWizardStepThree = ({
           className="flex gap-3 items-start cursor-pointer"
         >
           <Checkbox
+            data-testid="switch-wizard-step-three-acknowledge-checkbox"
             id={acknowledgeId}
             checked={isAcknowledged}
             onCheckedChange={(checked) => setIsAcknowledged(checked === true)}
@@ -229,6 +236,7 @@ export const SwitchWizardStepThree = ({
         </label>
 
         <Button
+          data-testid="switch-wizard-step-three-submit-btn"
           size="xl"
           width="full"
           onClick={handleSubmit}

--- a/src/components/wizard/switch-wizard-step-two-and-half.tsx
+++ b/src/components/wizard/switch-wizard-step-two-and-half.tsx
@@ -35,6 +35,7 @@ export const SwitchWizardStepTwoAndHalf = ({
 
   return (
     <Container
+      data-testid="switch-wizard-step-two-and-half-page"
       variant="vertical"
       className="py-6"
       backButtonLabel={backButtonLabel}
@@ -47,7 +48,12 @@ export const SwitchWizardStepTwoAndHalf = ({
         className="w-full flex flex-col gap-6 p-8 bg-white rounded-2xl"
       >
         <div className="flex flex-col gap-4 items-start">
-          <Text variant="headline4">Cluster Balances and Fees</Text>
+          <Text
+            data-testid="switch-wizard-step-two-and-half-title"
+            variant="headline4"
+          >
+            Cluster Balances and Fees
+          </Text>
           <Text variant="body-2-medium" className="text-gray-700">
             Your cluster's runway is determined by your deposited balance and
             the operator and network fees accrued over time. These fees scale
@@ -90,6 +96,7 @@ export const SwitchWizardStepTwoAndHalf = ({
             className="flex gap-3 items-start cursor-pointer"
           >
             <Checkbox
+              data-testid="switch-wizard-step-two-and-half-fees-checkbox"
               id={feesAcknowledgedId}
               checked={feesAcknowledged}
               onCheckedChange={(checked) =>
@@ -110,6 +117,7 @@ export const SwitchWizardStepTwoAndHalf = ({
             className="flex gap-3 items-start cursor-pointer"
           >
             <Checkbox
+              data-testid="switch-wizard-step-two-and-half-liquidation-checkbox"
               id={liquidationAcknowledgedId}
               checked={liquidationAcknowledged}
               onCheckedChange={(checked) =>
@@ -128,6 +136,7 @@ export const SwitchWizardStepTwoAndHalf = ({
         </div>
 
         <Button
+          data-testid="switch-wizard-step-two-and-half-next-btn"
           size="xl"
           width="full"
           onClick={handleNext}

--- a/src/components/wizard/switch-wizard-step-two.tsx
+++ b/src/components/wizard/switch-wizard-step-two.tsx
@@ -177,6 +177,7 @@ export const SwitchWizardStepTwo = ({
 
   return (
     <Container
+      data-testid="switch-wizard-step-two-page"
       variant="vertical"
       className="py-6"
       backButtonLabel={backButtonLabel}
@@ -192,7 +193,10 @@ export const SwitchWizardStepTwo = ({
           className="w-full flex flex-col gap-5 p-8 bg-white rounded-2xl"
         >
           <div className="flex flex-col gap-4 items-start">
-            <Text variant="headline4">
+            <Text
+              data-testid="switch-wizard-step-two-title"
+              variant="headline4"
+            >
               Select your validator funding period
             </Text>
             <Text variant="body-2-medium" className="text-gray-700">
@@ -429,6 +433,7 @@ export const SwitchWizardStepTwo = ({
           </div>
 
           <Button
+            data-testid="switch-wizard-step-two-next-btn"
             size="xl"
             width="full"
             type="submit"


### PR DESCRIPTION
## Summary

Adds **467 `data-testid` attributes** across the entire SSV web app so QA can build automated tests (Playwright / Cypress / Testing-Library) against staging with stable, deterministic selectors.

No behavior changes — every change is either a new `data-testid` attribute or a new prop that defaults to undefined.

## Coverage

| Surface | Count |
| --- | ---: |
| Dashboard (list pages, detail pages, all sub-flows, tables, picker) | 265 |
| Create-cluster wizard | 64 |
| Shared UI composites (pagination, toast, modals, file uploader, etc.) | 46 |
| Reshare DKG | 28 |
| Join (operator onboarding) | 27 |
| Switch-wizard (SSV → ETH migration) | 20 |
| Connect-wallet / compliance / maintenance / not-found | 17 |
| **Total** | **467** |

**Files changed:** 81

## What's included

- `TEST_IDS.md` at repo root — full conventions, per-page manifest, and shared-component contract. Read this first.
- Shared UI composites in `src/components/ui/` that have internal interactive elements (Pagination, Toast, TransactionModal, MultisigTransactionModal, JSONFileUploader, ExpandButton, ClusterBackBtnHeader) — given baked-in test IDs so call sites get them for free.
- Every route under `src/app/routes/` tagged at page container + every button / input / checkbox / link / submit / key value display.
- Tables (clusters, operators, validators, bulk select) carry **three attributes per row**:
  - `data-testid="<page>-<entity>-row"`
  - `data-testid-index="<n>"` — positional
  - `data-testid-entity="<id>"` — stable identifier (validator pubkey, operator ID, cluster hash)

## Conventions (full detail in `TEST_IDS.md`)

- Attribute: `data-testid` only
- Naming: `page-section-element-action` kebab-case (e.g. `dashboard-validator-list-row-remove-btn`)
- Most shared components (`Button`, `Input`, `Checkbox`, `Switch`, `Dialog*`, `CopyBtn`, etc.) already spread props — pass `data-testid` at the call site and it works.
- New UI added to this repo should follow the same conventions.

## Verification

- `pnpm type-check` ✅ passes
- `pnpm lint` ✅ passes (1 pre-existing unrelated warning in `migration-effective-balance-form.tsx`)
- No behavior changes — purely additive attribute changes

## How to verify in browser

```js
// After deploy to staging:
document.querySelectorAll('[data-testid]').length
// expect: large number (most rendered pages will show dozens-to-hundreds)

document.querySelectorAll('[data-testid-entity]').length
// expect: one per visible table row (validator/operator/cluster)
```

## History

This work was originally going to ship as 7 stacked PRs (one per area), but per Andrew's request was consolidated into one PR after local review. Earlier PRs #1867 and #1868 were closed; their work is included here. Memory of the agreed conventions is captured in [TEST_IDS.md](./TEST_IDS.md) so any new UI added going forward can follow the same rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)