### PR TITLE
chore: route mixpanel traffic to EU endpoint

### DIFF
--- a/src/lib/analytics/mixpanel/index.ts
+++ b/src/lib/analytics/mixpanel/index.ts
@@ -5,7 +5,9 @@ import { merge } from "lodash-es";
 import _mixpanel from "mixpanel-browser";
 
 if (import.meta.env.VITE_MIXPANEL_TOKEN)
-  _mixpanel.init(import.meta.env.VITE_MIXPANEL_TOKEN);
+  _mixpanel.init(import.meta.env.VITE_MIXPANEL_TOKEN, {
+    api_host: "https://api-eu.mixpanel.com",
+  });
 
 const getNetworkName = () => {
   const chainId = getChainId(config);


### PR DESCRIPTION
## What
Set the `mixpanel-browser` `api_host` to `https://api-eu.mixpanel.com` so all Mixpanel analytics from **app.ssv.network** is sent to Mixpanel's **EU data-residency** endpoint instead of the default (`api.mixpanel.com` / `api-js.mixpanel.com`).

## Why
PO request — Mixpanel traffic must go to the EU endpoint, needed in production before July.

## Change
`src/lib/analytics/mixpanel/index.ts`:
```diff
 if (import.meta.env.VITE_MIXPANEL_TOKEN)
-  _mixpanel.init(import.meta.env.VITE_MIXPANEL_TOKEN);
+  _mixpanel.init(import.meta.env.VITE_MIXPANEL_TOKEN, {
+    api_host: "https://api-eu.mixpanel.com",
+  });
```

One line, config-only — no behavioral change beyond the destination host.

## Notes
- **Explorer (`ssv-explorer`) is not in this PR.** That repo has no Mixpanel in source; it loads analytics via Google Tag Manager (`GTM-K3GR7M5`). If Mixpanel runs there, the EU-endpoint switch has to be made in the **GTM dashboard** (the Mixpanel tag config), not in a repo.
- Promotion path to production: this PR → `stage` (staging deploy) → subsequent `stage` → `main` PR (production deploy at app.ssv.network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)