### PR TITLE
chore: route mixpanel traffic to EU endpoint

### DIFF
--- a/src/lib/analytics/mixpanel/index.ts
+++ b/src/lib/analytics/mixpanel/index.ts
@@ -5,7 +5,9 @@ import { merge } from "lodash-es";
 import _mixpanel from "mixpanel-browser";
 
 if (import.meta.env.VITE_MIXPANEL_TOKEN)
-  _mixpanel.init(import.meta.env.VITE_MIXPANEL_TOKEN);
+  _mixpanel.init(import.meta.env.VITE_MIXPANEL_TOKEN, {
+    api_host: "https://api-eu.mixpanel.com",
+  });
 
 const getNetworkName = () => {
   const chainId = getChainId(config);


### PR DESCRIPTION
Cherry-pick of `1f88764f` from `stage`.

Sets `mixpanel-browser` `api_host` to `https://api-eu.mixpanel.com` so all analytics traffic from app.ssv.network goes to Mixpanel's EU residency endpoint instead of default `api.mixpanel.com`.

Single file, +3/−1. No other stage changes included.